### PR TITLE
Improve fit

### DIFF
--- a/pysidt/extensions.py
+++ b/pysidt/extensions.py
@@ -40,7 +40,7 @@ def split_mols(data, newgrp):
 
 def get_extension_edge(
     parent,
-    n_splits,
+    n_strucs_min,
     iter_max=np.inf,
     iter_item_cap=np.inf,
     r=None,
@@ -83,7 +83,7 @@ def get_extension_edge(
             r_un=r_un,
             r_site=r_site,
             r_morph=r_morph,
-            n_splits=n_splits,
+            n_strucs_min=n_strucs_min,
         )
 
         reg_dict = dict()
@@ -325,7 +325,7 @@ def get_extensions(
     basename="",
     atm_ind=None,
     atm_ind2=None,
-    n_splits=None,
+    n_strucs_min=None,
 ):
     """
     generate all allowed group extensions and their complements
@@ -335,8 +335,8 @@ def get_extensions(
     #                 extents=list, RnH=list, typ=list)
     extents = []
 
-    if n_splits is None:
-        n_splits = len(grp.split())
+    if n_strucs_min is None:
+        n_strucs_min = len(grp.split())
 
     # generate appropriate r and r!H
     if r is None:
@@ -521,7 +521,7 @@ def get_extensions(
                 if j < i and not grp.has_bond(atm, atm2):
                     extents.extend(
                         specify_internal_new_bond_extensions(
-                            grp, i, j, n_splits, basename, r_bonds
+                            grp, i, j, n_strucs_min, basename, r_bonds
                         )
                     )
                 elif j < i:
@@ -549,7 +549,7 @@ def get_extensions(
         if j < i and not grp.has_bond(atm, atm2):
             extents.extend(
                 specify_internal_new_bond_extensions(
-                    grp, i, j, n_splits, basename, r_bonds
+                    grp, i, j, n_strucs_min, basename, r_bonds
                 )
             )
         if grp.has_bond(atm, atm2):
@@ -706,7 +706,7 @@ def get_extensions(
             if j < i and not grp.has_bond(atm, atm2):
                 extents.extend(
                     specify_internal_new_bond_extensions(
-                        grp, i, j, n_splits, basename, r_bonds
+                        grp, i, j, n_strucs_min, basename, r_bonds
                     )
                 )
             elif j < i:
@@ -952,7 +952,7 @@ def specify_morphology_extensions(grp, i, basename, r_morph):
     return grps
 
 
-def specify_internal_new_bond_extensions(grp, i, j, n_splits, basename, r_bonds):
+def specify_internal_new_bond_extensions(grp, i, j, n_strucs_min, basename, r_bonds):
     """
     generates extensions for creation of a bond (of undefined order)
     between two atoms indexed i,j that already exist in the group and are unbonded
@@ -989,7 +989,7 @@ def specify_internal_new_bond_extensions(grp, i, j, n_splits, basename, r_bonds)
         atom_type_j_str = atom_type_j[0].label
 
     if (
-        len(newgrp.split()) < n_splits
+        len(newgrp.split()) < n_strucs_min
     ):  # if this formed a bond between two seperate groups in the
         return []
     else:

--- a/pysidt/sidt.py
+++ b/pysidt/sidt.py
@@ -52,7 +52,7 @@ class SubgraphIsomorphicDecisionTree:
         self,
         root_group=None,
         nodes=None,
-        n_splits=1,
+        n_strucs_min=1,
         iter_max=2,
         iter_item_cap=100,
         r=None,
@@ -73,7 +73,7 @@ class SubgraphIsomorphicDecisionTree:
             r_morph = []
 
         self.nodes = nodes
-        self.n_splits = n_splits
+        self.n_strucs_min = n_strucs_min
         self.iter_max = iter_max
         self.iter_item_cap = iter_item_cap
         self.r = r
@@ -124,7 +124,7 @@ class SubgraphIsomorphicDecisionTree:
 
         out, gave_up_split = get_extension_edge(
             node,
-            self.n_splits,
+            self.n_strucs_min,
             r=self.r,
             r_bonds=self.r_bonds,
             r_un=self.r_un,
@@ -343,7 +343,7 @@ class MultiEvalSubgraphIsomorphicDecisionTree(SubgraphIsomorphicDecisionTree):
         decomposition,
         root_group=None,
         nodes=None,
-        n_splits=1,
+        n_strucs_min=1,
         iter_max=2,
         iter_item_cap=100,
         fract_nodes_expand_per_iter=0,
@@ -356,7 +356,7 @@ class MultiEvalSubgraphIsomorphicDecisionTree(SubgraphIsomorphicDecisionTree):
         super().__init__(
             root_group=root_group,
             nodes=nodes,
-            n_splits=n_splits,
+            n_strucs_min=n_strucs_min,
             iter_max=iter_max,
             iter_item_cap=iter_item_cap,
             r=r,

--- a/pysidt/sidt.py
+++ b/pysidt/sidt.py
@@ -783,6 +783,11 @@ class MultiEvalSubgraphIsomorphicDecisionTree(SubgraphIsomorphicDecisionTree):
             self.node_uncertainties.update(
                 {node.name: 1.0 for i, node in enumerate(nodes)}
             )
+
+    def assign_depths(self):
+        root = self.root
+        _assign_depths(root)
+
     def evaluate(self, mol):
         """
         Evaluate tree for a given possibly labeled mol
@@ -843,3 +848,9 @@ class MultiEvalSubgraphIsomorphicDecisionTree(SubgraphIsomorphicDecisionTree):
             self.r_site,
             self.r_morph,
         )
+
+
+def _assign_depths(node, depth=0):
+    node.depth = depth
+    for child in node.children:
+        _assign_depths(child, depth=depth + 1)

--- a/pysidt/sidt.py
+++ b/pysidt/sidt.py
@@ -352,6 +352,24 @@ def read_nodes(file):
 
 
 class MultiEvalSubgraphIsomorphicDecisionTree(SubgraphIsomorphicDecisionTree):
+    """
+    Makes prediction for a molecule based on multiple evaluations.
+
+    Args:
+        `decomposition`: method to decompose a molecule into substructure contributions.
+        `root_group`: root group for the tree
+        `nodes`: dictionary of nodes for the tree
+        `n_strucs_min`: minimum number of disconnected structures that can be in the group. Default is 1.
+        `iter_max`: maximum number of times the extension generation algorithm is allowed to expand structures looking for additional splits. Default is 2.
+        `iter_item_cap`: maximum number of structures the extension generation algorithm can send for expansion. Default is 100.
+        `fract_nodes_expand_per_iter`: fraction of nodes to split at each iteration. If 0, only 1 node will be split at each iteration.
+        `r`: atom types to generate extensions. If None, all atom types will be used.
+        `r_bonds`: bond types to generate extensions. If None, [1, 2, 3, 1.5, 4] will be used.
+        `r_un`: unpaired electrons to generate extensions. If None, [0, 1, 2, 3] will be used.
+        `r_site`: surface sites to generate extensions. If None, [] will be used.
+        `r_morph`: surface morphology to generate extensions. If None, [] will be used.
+    """
+
     def __init__(
         self,
         decomposition,

--- a/pysidt/sidt.py
+++ b/pysidt/sidt.py
@@ -385,6 +385,17 @@ class MultiEvalSubgraphIsomorphicDecisionTree(SubgraphIsomorphicDecisionTree):
         r_site=None,
         r_morph=None,
     ):
+        if nodes is None:
+            nodes = dict()
+        if r_bonds is None:
+            r_bonds = [1, 2, 3, 1.5, 4]
+        if r_un is None:
+            r_un = [0, 1, 2, 3]
+        if r_site is None:
+            r_site = []
+        if r_morph is None:
+            r_morph = []
+
         super().__init__(
             root_group=root_group,
             nodes=nodes,

--- a/pysidt/sidt.py
+++ b/pysidt/sidt.py
@@ -14,7 +14,14 @@ logging.basicConfig(level=logging.INFO)
 
 class Node:
     def __init__(
-        self, group=None, items=None, rule=None, parent=None, children=None, name=None
+        self,
+        group=None,
+        items=None,
+        rule=None,
+        parent=None,
+        children=None,
+        name=None,
+        depth=None,
     ):
         if items is None:
             items = []
@@ -27,9 +34,10 @@ class Node:
         self.parent = parent
         self.children = children
         self.name = name
+        self.depth = depth
 
     def __repr__(self) -> str:
-        return f"{self.name} {self.rule}"
+        return f"{self.name} rule: {self.rule} depth: {self.depth}"
 
 
 class Datum:

--- a/pysidt/sidt.py
+++ b/pysidt/sidt.py
@@ -296,7 +296,7 @@ class SubgraphIsomorphicDecisionTree:
         children = self.root.children
         node = self.root
 
-        while children != []:
+        while children:
             for child in children:
                 if mol.is_subgraph_isomorphic(
                     child.group, generate_initial_map=True, save_order=True

--- a/pysidt/sidt.py
+++ b/pysidt/sidt.py
@@ -145,8 +145,6 @@ class SubgraphIsomorphicDecisionTree:
         if not out and not recursing:
             logging.info("recursing")
             logging.info(node.group.to_adjacency_list())
-            # for item in node.items:
-            #     logging.error(item.to_adjacency_list())
             node.group.clear_reg_dims()
             return self.generate_extensions(node, recursing=True)
 

--- a/pysidt/sidt.py
+++ b/pysidt/sidt.py
@@ -340,6 +340,7 @@ def read_nodes(file):
             parent=d["parent"],
             children=d["children"],
             name=d["name"],
+            depth=d["depth"],
         )
 
     for n, node in nodes.items():

--- a/pysidt/sidt.py
+++ b/pysidt/sidt.py
@@ -185,7 +185,13 @@ class SubgraphIsomorphicDecisionTree:
         logging.info("Choose extension {}".format(name))
 
         node = Node(
-            group=grp, items=new, rule=None, parent=parent, children=[], name=name
+            group=grp,
+            items=new,
+            rule=None,
+            parent=parent,
+            children=[],
+            name=name,
+            depth=parent.depth + 1,
         )
         self.nodes[name] = node
         parent.children.append(node)
@@ -204,6 +210,7 @@ class SubgraphIsomorphicDecisionTree:
                 parent=parent,
                 children=[],
                 name=cextname,
+                depth=parent.depth + 1,
             )
             self.nodes[cextname] = nodec
             parent.children.append(nodec)
@@ -423,7 +430,13 @@ class MultiEvalSubgraphIsomorphicDecisionTree(SubgraphIsomorphicDecisionTree):
         grp, grpc, name, typ, indc = exts[ind]
 
         node = Node(
-            group=grp, items=new, rule=None, parent=parent, children=[], name=name
+            group=grp,
+            items=new,
+            rule=None,
+            parent=parent,
+            children=[],
+            name=name,
+            depth=parent.depth + 1,
         )
 
         assert not (name in self.nodes.keys()), name
@@ -458,6 +471,7 @@ class MultiEvalSubgraphIsomorphicDecisionTree(SubgraphIsomorphicDecisionTree):
                 parent=parent,
                 children=[],
                 name=cextname,
+                depth=parent.depth + 1,
             )
 
             self.nodes[cextname] = nodec

--- a/pysidt/sidt.py
+++ b/pysidt/sidt.py
@@ -417,6 +417,7 @@ class MultiEvalSubgraphIsomorphicDecisionTree(SubgraphIsomorphicDecisionTree):
         self.validation_set = None
         self.best_tree_nodes = None
         self.min_val_error = np.inf
+        self.assign_depths()
 
     def select_nodes(self, num=1):
         """


### PR DESCRIPTION
This builds on top of https://github.com/zadorlab/PySIDT/pull/7 and https://github.com/zadorlab/PySIDT/pull/7 should be merged in first. 

I changed the multieval tree fitting scheme. I found that the current fitting scheme does not guarantee smaller values for nodes closer to the terminal nodes. Instead, I took inspiration from the gradient boosting to do the fitting layer by layer, from top of the tree (root) to the bottom (terminal nodes). 