### PR TITLE
Multi-evaluation Binary Classifier

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,3 +36,4 @@ jobs:
         run: |
           pytest --nbmake IPython/multi_eval_SIDT_example.ipynb
           pytest --nbmake IPython/Surface_Diffusion_single_eval_SIDT_example.ipynb
+          pytest --nbmake IPython/Unstable_QOOH_Binary_Classification.ipynb

--- a/IPython/Unstable_QOOH_Binary_Classification.ipynb
+++ b/IPython/Unstable_QOOH_Binary_Classification.ipynb
@@ -1,0 +1,158 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2e602b7f-c603-4de2-a05d-9f0c73d41b0b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pysidt.sidt import read_nodes, write_nodes, MultiEvalSubgraphIsomorphicDecisionTreeBinaryClassifier, Datum\n",
+    "from pysidt.plotting import plot_tree\n",
+    "from pysidt.decomposition import atom_decomposition_noH\n",
+    "from molecule.molecule import Molecule, Group\n",
+    "from molecule.molecule.atomtype import ATOMTYPES\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "87a03282-d729-499a-9479-5001a1b1d49e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#In general species of the form [R.]OOH are usually not stable and decompose to R=O + OH, an exception to this is CH2OOH\n",
+    "stable_smiles = [\"CC\",\"C\",\"O\",\"CO\",\"CCC\",\"C[CH]C\",\"C[CH]CC\",\"C[CH]OC\",\"C[CH]CO\",\"C=C\",\"C=CC\",\"CCCC\",\"CCCO\",\"COC\",\"CCOC\",\n",
+    "                 \"[OH]\",\"[CH3]\",\"[CH2]OO\", \"C[CH2]\", \"COO\", \"CCOO\",\"CCCOO\",\"[CH2]CCC\",\"C[CH]OC\",\"C[CH]O\", \"CC[CH]CC\", \"OC[CH]CC\",\n",
+    "                \"C=CCC\", \"O[CH]CC\", \"CO[CH]CC\",\"CO[CH]OC\", \"O=CC\", \"C=CCCC\", \"O=CCCC\", \"CCCCCC\", \"CCCCCCC\", \"[CH2]OCO[CH]C\",\n",
+    "                 \"O[CH]CCCO[CH]CC\", \"CCC[CH]C\",]\n",
+    "unstable_smiles = [\"C[CH]OO\",\"CC[CH]OO\",\"O=CC[CH]OO\",\"CCC[CH]OO\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bd624b7e-f9aa-4fba-bf09-2898d747f441",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = []\n",
+    "for sm in stable_smiles:\n",
+    "    data.append(Datum(Molecule().from_smiles(sm),True))\n",
+    "for sm in unstable_smiles:\n",
+    "    data.append(Datum(Molecule().from_smiles(sm),False))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e49e1fc1-6ea3-43a3-b76f-166e3b951079",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "root = Group().from_adjacency_list(\"\"\"\n",
+    "1 * R ux px cx\n",
+    "\"\"\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1284bbee-a3ca-4f43-9068-2456e7d15a57",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tree = MultiEvalSubgraphIsomorphicDecisionTreeBinaryClassifier(atom_decomposition_noH,root_group=root,\n",
+    "                                               r=[ATOMTYPES[x] for x in [\"C\",\"O\"]],\n",
+    "                                               r_bonds=[1,2,3],\n",
+    "                                                         r_un=[0,1],\n",
+    "                                               r_site=[], \n",
+    "                                              )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "84c4e20f-c6e6-4208-b876-d016a372f387",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tree.generate_tree(data=data,max_nodes=100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2dc98a30-4cd7-4f5d-9d9b-84720886155e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#initial trees are much larger than it needs to be because a \"good split of data\" != \"change in classification\"\n",
+    "plot_tree(tree)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7145d6f0-8e07-4804-a565-8bfadf09955c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#We then merge nodes when possible and regularize\n",
+    "tree.trim_tree()\n",
+    "tree.regularize()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8f726167-e1ac-40e1-af71-edf53105cf66",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#After trimming and regularizing we have a much simpler tree that is easy to evaluate and analyze\n",
+    "plot_tree(tree)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "24a88f4a-04a0-427d-804a-860d840aec6d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tree.analyze_error()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "437dbc01-e1af-4c2c-9b34-bebdc1588838",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pysidt/plotting.py
+++ b/pysidt/plotting.py
@@ -1,27 +1,31 @@
 from IPython.display import Image, display
 import pydot
 import os
+import numpy as np
 
-
-def plot_tree(sidt, images=True):
+def plot_tree(sidt, images=True, depth=np.inf):
     graph = pydot.Dot("treestruct", graph_type="digraph", overlap="false")
     graph.set_fontname("sans")
     graph.set_fontsize("10")
     if not os.path.exists("./tree"):
         os.makedirs("./tree")
+    out_nodes = dict()
     for name, node in sidt.nodes.items():
-        n = pydot.Node(name=name, label=name, fontname="Helvetica", fontsize="16")
-        if images:
-            img = node.group.draw("png")
-            with open("./tree/" + node.name + ".png", "wb") as f:
-                f.write(img)
-            n.set_image(os.path.abspath("./tree/" + node.name + ".png"))
-            n.set_label(" ")
-        graph.add_node(n)
-    for name, node in sidt.nodes.items():
+        if node.depth <= depth:
+            n = pydot.Node(name=name, label=name, fontname="Helvetica", fontsize="16")
+            if images:
+                img = node.group.draw("png")
+                with open("./tree/" + node.name + ".png", "wb") as f:
+                    f.write(img)
+                n.set_image(os.path.abspath("./tree/" + node.name + ".png"))
+                n.set_label(" ")
+            graph.add_node(n)
+            out_nodes[name] = node
+    for name, node in out_nodes.items():
         for nod in node.children:
-            edge = pydot.Edge(node.name, nod.name)
-            graph.add_edge(edge)
+            if nod.name in out_nodes.keys():
+                edge = pydot.Edge(node.name, nod.name)
+                graph.add_edge(edge)
     graph.write_dot("./tree/tree.dot")
     graph.write_png("./tree/tree.png")
     plt = Image("./tree/tree.png")

--- a/pysidt/plotting.py
+++ b/pysidt/plotting.py
@@ -10,14 +10,16 @@ def plot_tree(sidt, images=True, depth=np.inf):
     if not os.path.exists("./tree"):
         os.makedirs("./tree")
     out_nodes = dict()
+    index = -1
     for name, node in sidt.nodes.items():
+        index += 1
         if node.depth <= depth:
             n = pydot.Node(name=name, label=name, fontname="Helvetica", fontsize="16")
-            if images:
+            if images and node.group is not None:
                 img = node.group.draw("png")
-                with open("./tree/" + node.name + ".png", "wb") as f:
+                with open("./tree/" + str(index) + ".png", "wb") as f:
                     f.write(img)
-                n.set_image(os.path.abspath("./tree/" + node.name + ".png"))
+                n.set_image(os.path.abspath("./tree/" + str(index) + ".png"))
                 n.set_label(" ")
             graph.add_node(n)
             out_nodes[name] = node

--- a/pysidt/regularization.py
+++ b/pysidt/regularization.py
@@ -25,6 +25,9 @@ def simple_regularization(node, Rx, Rbonds, Run, Rsite, Rmorph, test=True):
 
     grp = node.group
     data = node.items
+    
+    if grp is None:
+        return
 
     R = Rx[:]
     if ATOMTYPES["X"] in R:

--- a/pysidt/sidt.py
+++ b/pysidt/sidt.py
@@ -946,6 +946,74 @@ class MultiEvalSubgraphIsomorphicDecisionTree(SubgraphIsomorphicDecisionTree):
             self.r_morph,
         )
 
+class MultiEvalSubgraphIsomorphicDecisionTreeBinaryClassifier(MultiEvalSubgraphIsomorphicDecisionTree):
+    """
+    This SIDT class is a multi-evaluation "and" classifier 
+    Every molecular decomposition is evaluated in the tree to True or False
+    If any decomposition is False the input is classified as False, otherwise it is classified as True
+    Note that one can use this as an "or" classifier by flipping the query of interest and the training data (False => True and True => False)
+    Args:
+        `decomposition`: method to decompose a molecule into substructure contributions.
+        `root_group`: root group for the tree
+        `nodes`: dictionary of nodes for the tree
+        `n_strucs_min`: minimum number of disconnected structures that can be in the group. Default is 1.
+        `iter_max`: maximum number of times the extension generation algorithm is allowed to expand structures looking for additional splits. Default is 2.
+        `iter_item_cap`: maximum number of structures the extension generation algorithm can send for expansion. Default is 100.
+        `fract_nodes_expand_per_iter`: fraction of nodes to split at each iteration. If 0, only 1 node will be split at each iteration.
+        `r`: atom types to generate extensions. If None, all atom types will be used.
+        `r_bonds`: bond types to generate extensions. If None, [1, 2, 3, 1.5, 4] will be used.
+        `r_un`: unpaired electrons to generate extensions. If None, [0, 1, 2, 3] will be used.
+        `r_site`: surface sites to generate extensions. If None, [] will be used.
+        `r_morph`: surface morphology to generate extensions. If None, [] will be used.
+        `fract_threshold_to_predict_true`: fraction of relevant structures that favor true classification at which True will be predicted, this helps the algorithm avoid either false negatives or false positives when one is significantly preferable over the other  
+    """
+    def __init__(
+        self,
+        decomposition,
+        root_group=None,
+        nodes=None,
+        initial_root_splits=None,
+        n_strucs_min=1,
+        iter_max=2,
+        iter_item_cap=100,
+        fract_nodes_expand_per_iter=0,
+        r=None,
+        r_bonds=None,
+        r_un=None,
+        r_site=None,
+        r_morph=None,
+        fract_threshold_to_predict_true=0.5,
+    ):
+        if nodes is None:
+            nodes = dict()
+        if r_bonds is None:
+            r_bonds = [1, 2, 3, 1.5, 4]
+        if r_un is None:
+            r_un = [0, 1, 2, 3]
+        if r_site is None:
+            r_site = []
+        if r_morph is None:
+            r_morph = []
+
+        super().__init__(
+            decomposition=decomposition,
+            root_group=root_group,
+            nodes=nodes,
+            initial_root_splits=initial_root_splits,
+            n_strucs_min=n_strucs_min,
+            iter_max=iter_max,
+            iter_item_cap=iter_item_cap,
+            fract_nodes_expand_per_iter=fract_nodes_expand_per_iter,
+            r=r,
+            r_bonds=r_bonds,
+            r_un=r_un,
+            r_site=r_site,
+            r_morph=r_morph,
+            )
+
+        self.fract_threshold_to_predict_true = fract_threshold_to_predict_true
+        self.max_accuracy = 0.0
+
 
 def _assign_depths(node, depth=0):
     node.depth = depth

--- a/pysidt/sidt.py
+++ b/pysidt/sidt.py
@@ -499,6 +499,7 @@ class MultiEvalSubgraphIsomorphicDecisionTree(SubgraphIsomorphicDecisionTree):
         self.datums = None
         self.validation_set = None
         self.best_tree_nodes = None
+        self.best_rule_map = None
         self.min_val_error = np.inf
         self.assign_depths()
 
@@ -759,8 +760,8 @@ class MultiEvalSubgraphIsomorphicDecisionTree(SubgraphIsomorphicDecisionTree):
                         children_to_remove.append(child)
                 for child in children_to_remove:
                     node.children.remove(child)
-
-            self.fit_tree(data=None, check_data=False, alpha=alpha)
+            for n,node in self.nodes.items():
+                node.rule = self.best_rule_map[n]
 
     def fit_tree(self, data=None, check_data=True, alpha=0.1):
         """
@@ -822,13 +823,13 @@ class MultiEvalSubgraphIsomorphicDecisionTree(SubgraphIsomorphicDecisionTree):
             if max_mae < self.min_val_error:
                 self.min_val_error = max_mae
                 self.best_tree_nodes = list(self.nodes.keys())
-                self.check_mol_node_maps()
                 self.bestA = A
                 self.best_nodes = {k: v for k, v in self.nodes.items()}
                 self.best_mol_node_maps = {
                     k: {"mols": v["mols"][:], "nodes": v["nodes"][:]}
                     for k, v in self.mol_node_maps.items()
                 }
+                self.best_rule_map = {name:self.nodes[name].rule for name in self.best_tree_nodes}
             self.val_mae = val_mae
             logging.info("validation MAE: {}".format(self.val_mae))
 

--- a/pysidt/sidt.py
+++ b/pysidt/sidt.py
@@ -61,6 +61,7 @@ class SubgraphIsomorphicDecisionTree:
         self,
         root_group=None,
         nodes=None,
+        initial_root_splits=None,
         n_strucs_min=1,
         iter_max=2,
         iter_item_cap=100,
@@ -100,6 +101,12 @@ class SubgraphIsomorphicDecisionTree:
         elif root_group:
             self.root = Node(root_group, name="Root", depth=0)
             self.nodes = {"Root": self.root}
+            if initial_root_splits:
+                for i,grp in enumerate(initial_root_splits):
+                    name = "Root_"+str(i)
+                    n = Node(grp,name=name,depth=1,parent=self.root)
+                    self.root.children.append(n)
+                    self.nodes[name] = n
 
     def load(self, nodes):
         self.nodes = nodes
@@ -268,6 +275,8 @@ class SubgraphIsomorphicDecisionTree:
 
             self.clear_data()
             self.root.items = data[:]
+            if len(self.nodes) > 1:
+                self.descend_training_from_top()
 
         node = self.select_node()
 
@@ -458,6 +467,7 @@ class MultiEvalSubgraphIsomorphicDecisionTree(SubgraphIsomorphicDecisionTree):
         decomposition,
         root_group=None,
         nodes=None,
+        initial_root_splits=None,
         n_strucs_min=1,
         iter_max=2,
         iter_item_cap=100,
@@ -482,6 +492,7 @@ class MultiEvalSubgraphIsomorphicDecisionTree(SubgraphIsomorphicDecisionTree):
         super().__init__(
             root_group=root_group,
             nodes=nodes,
+            initial_root_splits=initial_root_splits,
             n_strucs_min=n_strucs_min,
             iter_max=iter_max,
             iter_item_cap=iter_item_cap,
@@ -711,6 +722,8 @@ class MultiEvalSubgraphIsomorphicDecisionTree(SubgraphIsomorphicDecisionTree):
             `alpha`: regularization parameter for Lasso regression
         """
         self.setup_data(data, check_data=check_data)
+        if len(self.nodes) > 1:
+            self.descend_training_from_top(only_specific_match=True)
         self.val_mae = np.inf
         self.skip_nodes = []
         self.new_nodes = []

--- a/pysidt/sidt.py
+++ b/pysidt/sidt.py
@@ -1459,6 +1459,16 @@ class MultiEvalSubgraphIsomorphicDecisionTreeBinaryClassifier(MultiEvalSubgraphI
         for name in to_delete:
             del self.nodes[name]
             
+def analyze_binary_classification(preds,true_values):
+    P = sum(true_values)
+    N = len(preds) - P
+    PP = sum(preds)
+    PN = len(preds) - PP
+    TP = sum([True for i in range(len(preds)) if preds[i] and true_values[i]])
+    FN = sum([True for i in range(len(preds)) if not preds[i] and true_values[i]])
+    FP = sum([True for i in range(len(preds)) if preds[i] and not true_values[i]])
+    TN = sum([True for i in range(len(preds)) if not preds[i] and not true_values[i]])
+    return P,N,PP,PN,TP,FN,FP,TN
 
 def _assign_depths(node, depth=0):
     node.depth = depth

--- a/pysidt/sidt.py
+++ b/pysidt/sidt.py
@@ -885,12 +885,14 @@ class MultiEvalSubgraphIsomorphicDecisionTree(SubgraphIsomorphicDecisionTree):
         root = self.root
         _assign_depths(root)
 
-    def evaluate(self, mol):
+    def evaluate(self, mol, trace=False):
         """
         Evaluate tree for a given possibly labeled mol
         """
         out = 0.0
         decomp = self.decomposition(mol)
+        if trace:
+            tr = []
         for d in decomp:
             children = self.root.children
             node = self.root
@@ -907,8 +909,13 @@ class MultiEvalSubgraphIsomorphicDecisionTree(SubgraphIsomorphicDecisionTree):
                         break
                 else:
                     boo = False
+            if trace:
+                tr.append(node.name)
 
-        return out
+        if trace:
+            return out,tr
+        else:
+            return out
 
     def descend_node(self, node, only_specific_match=True):
         data_to_add = {child: [] for child in node.children}

--- a/pysidt/sidt.py
+++ b/pysidt/sidt.py
@@ -1228,6 +1228,32 @@ class MultiEvalSubgraphIsomorphicDecisionTreeBinaryClassifier(MultiEvalSubgraphI
             parent.items = comp
             parent.rule = comp_rule
 
+    def evaluate(self, mol):
+        """
+        Evaluate tree for a given possibly labeled mol
+        """
+        out = 0.0
+        decomp = self.decomposition(mol)
+        for d in decomp:
+            children = self.root.children
+            node = self.root
+            boo = True
+            while boo:
+                for child in children:
+                    if d.is_subgraph_isomorphic(
+                        child.group, generate_initial_map=True, save_order=True
+                    ):
+                        children = child.children
+                        node = child
+                        break
+                else:
+                    boo = False
+
+            if not node.rule:
+                return False
+                    
+        return True
+
 
 def _assign_depths(node, depth=0):
     node.depth = depth

--- a/pysidt/sidt.py
+++ b/pysidt/sidt.py
@@ -1366,6 +1366,99 @@ class MultiEvalSubgraphIsomorphicDecisionTreeBinaryClassifier(MultiEvalSubgraphI
             for n,node in self.nodes.items():
                 node.rule = self.best_rule_map[n]
             
+    def trim_tree(self):
+        """
+        Many of the tree extension sets improve the split, but do not change predictions
+        this function 1) merges nodes with their parents if they can be removed without affecting classifications
+        2) merges nodes with their parents if they do not result in different predictions
+        """
+
+        self.datum_truth_map = {datum:[getattr(n,"rule") for n in self.mol_node_maps[datum]["nodes"]] for datum in self.datums}
+        self.datum_node_map = {datum:[n for n in self.mol_node_maps[datum]["nodes"]] for datum in self.datums}
+
+        check_nodes = True
+        while check_nodes:
+            check_nodes = False
+            items_to_delete = []
+            items_to_delete_values = []
+            for name,node in self.nodes.items():
+                if node.rule or node.parent is None:
+                    continue
+                break_loop = False
+                for k, datum in enumerate(self.datums):
+                    boos = self.datum_truth_map[datum]
+                    nodes = self.datum_node_map[datum]
+                    c = boos.count(False)
+                    for i in range(len(nodes)):
+                        if not datum.value and c == 1: #classification at this node matters for proper classification of this training item
+                            break_loop = True
+                            break
+                    if break_loop:
+                        break
+                else:
+                    items_to_delete.append(node)
+                    items_to_delete_values.append(node.items)
+                    
+            if items_to_delete:
+                ind = np.argmin(np.array(items_to_delete_values))
+                node = items_to_delete[ind]
+                logging.info(f"Deleting node {node.name} because unnecessary for classification")
+                node.parent.children.remove(node)
+                node.parent.children.extend(node.children)
+                node.parent.items += node.items
+                for n in item_to_delete.children:
+                    n.parent = item_to_delete.parent
+                check_nodes = True
+        
+        #merge nodes with parents that give same predictions 
+        self.setup_data(data=self.datums)
+        to_delete = []
+        boo = True
+        while boo:
+            temp_to_delete = []
+            for name,node in self.nodes.items():
+                if name in to_delete:
+                    continue
+                if node.parent and node.rule == node.parent.rule:
+                    seen_node = False
+                    for child in node.parent.children:
+                        break_loop = False
+                        if child is node:
+                            seen_node = True
+                            continue
+                        if seen_node:
+                            for k, datum in enumerate(self.datums):
+                                for i, d in enumerate(self.mol_node_maps[datum]["mols"]):
+                                    if d.is_subgraph_isomorphic(node.group, generate_initial_map=True, save_order=True):
+                                        if all(not d.is_subgraph_isomorphic(c.group, generate_initial_map=True, save_order=True) for c in node.children):
+                                            if d.is_subgraph_isomorphic(child.group, generate_initial_map=True, save_order=True):
+                                                break_loop = True
+                                                break
+                            if break_loop:
+                                break
+                    else:
+                        logging.info(f"Removing node {node.name}")
+
+                        ind = node.parent.children.index(node)
+                        node.parent.children = node.parent.children[:ind] + node.children + node.parent.children[ind+1:]
+                        for n in node.children:
+                            n.parent = node.parent
+                        node.parent.items += node.items
+                        self.analyze_error()
+                            
+                        for k, datum in enumerate(self.datums):
+                            for i, n in enumerate(self.mol_node_maps[datum]["nodes"]):
+                                if n == node:
+                                    assert self.mol_node_maps[datum]["nodes"][i].rule == node.parent.rule
+                                    self.mol_node_maps[datum]["nodes"][i] = node.parent
+                                    
+                        temp_to_delete.append(name)
+            to_delete.extend(temp_to_delete)
+            boo = len(temp_to_delete) > 0 
+            
+        for name in to_delete:
+            del self.nodes[name]
+            
 
 def _assign_depths(node, depth=0):
     node.depth = depth

--- a/pysidt/sidt.py
+++ b/pysidt/sidt.py
@@ -1324,6 +1324,9 @@ class MultiEvalSubgraphIsomorphicDecisionTreeBinaryClassifier(MultiEvalSubgraphI
         self.setup_data(data, check_data=check_data)
         if len(self.nodes) > 1:
             self.descend_training_from_top(only_specific_match=True)
+            for node in self.nodes.values():
+                if node.rule is None:
+                    node.rule = True
         self.val_mae = np.inf
         self.skip_nodes = []
         self.new_nodes = []

--- a/pysidt/sidt.py
+++ b/pysidt/sidt.py
@@ -1014,6 +1014,49 @@ class MultiEvalSubgraphIsomorphicDecisionTreeBinaryClassifier(MultiEvalSubgraphI
         self.fract_threshold_to_predict_true = fract_threshold_to_predict_true
         self.max_accuracy = 0.0
 
+    def select_nodes(self):
+        """
+        Picks the node with the most decompositions who a change in the decomposition's classification might improve overall classification
+        adding multiple nodes would require the datum map variables to need updated before analyzing what data to split the node over as
+        those maps may change when a node is added
+        """
+        self.datum_truth_map = {datum:[getattr(n,"rule") for n in self.mol_node_maps[datum]["nodes"]] for datum in self.datums}
+        self.datum_node_map = {datum:[n for n in self.mol_node_maps[datum]["nodes"]] for datum in self.datums}
+        
+        if len(self.nodes) > 1:
+            node_scores = {node.name:0 for node in self.nodes.values()}
+            for k, datum in enumerate(self.datums):
+                boos = self.datum_truth_map[datum]
+                nodes = self.datum_node_map[datum]
+                c = boos.count(False)
+                for i in range(len(nodes)):
+                    if datum.value and c >= 1:
+                        if not boos[i]:
+                            node_scores[nodes[i].name] += 1
+                    elif not datum.value and c == 0:
+                        if boos[i]:
+                            node_scores[nodes[i].name] += 1
+
+            rulevals = [
+                node_scores[node.name]
+                if len(node.items) > 1
+                and not (node.name in self.new_nodes)
+                and not (node.name in self.skip_nodes)
+                else 0.0
+                for node in self.nodes.values()
+            ]
+            inds = np.argsort(rulevals)
+            ind = np.argmax(rulevals)
+            v = np.max(rulevals)
+            node = list(self.nodes.values())[ind]
+            logging.info(f"selected {node.name}")
+            if v == 0:
+                return None
+            else:
+                return [node]
+        else:
+            return list(self.nodes.values())
+
 
 def _assign_depths(node, depth=0):
     node.depth = depth

--- a/pysidt/sidt.py
+++ b/pysidt/sidt.py
@@ -1406,8 +1406,8 @@ class MultiEvalSubgraphIsomorphicDecisionTreeBinaryClassifier(MultiEvalSubgraphI
                 node.parent.children.remove(node)
                 node.parent.children.extend(node.children)
                 node.parent.items += node.items
-                for n in item_to_delete.children:
-                    n.parent = item_to_delete.parent
+                for n in items_to_delete.children:
+                    n.parent = items_to_delete.parent
                 check_nodes = True
         
         #merge nodes with parents that give same predictions 

--- a/pysidt/sidt.py
+++ b/pysidt/sidt.py
@@ -580,7 +580,7 @@ class MultiEvalSubgraphIsomorphicDecisionTree(SubgraphIsomorphicDecisionTree):
                     )
                     self.mol_node_maps[datum]["nodes"][i] = node
 
-        print("adding node {}".format(name))
+        logging.info("adding node {}".format(name))
 
         if grpc:
             frags = name.split("_")


### PR DESCRIPTION
This adds an SIDT algorithm for Multi-Evaluation binary classification. 

It also adds some smaller improvements:
Allows plotting only to specified depth
Saves rules as well as nodes in postpruning
allows specification of an initial set of splits from the root node

An example notebook for unstable Q.OOH classification is provided. 