### PR TITLE
General Fixes and Improvements

### DIFF
--- a/pysidt/extensions.py
+++ b/pysidt/extensions.py
@@ -371,6 +371,7 @@ def get_extensions(
         RnH = R[:]
         RnH.remove(ATOMTYPES["H"])
         RxnH = R[:]
+        RxnH.remove(ATOMTYPES["H"])
     elif ATOMTYPES["X"] in r:
         RxnH = r[:]
         R = r[:]
@@ -410,7 +411,7 @@ def get_extensions(
                     elif typ[0].label == "R!H":
                         extents.extend(
                             specify_atom_extensions(
-                                grp, i, basename, list(set(atm.reg_dim_atm[0]) & set(R))
+                                grp, i, basename, list(set(atm.reg_dim_atm[0]) & set(RnH))
                             )
                         )
                     elif typ[0].label == "Rx":

--- a/pysidt/sidt.py
+++ b/pysidt/sidt.py
@@ -1001,8 +1001,6 @@ class MultiEvalSubgraphIsomorphicDecisionTree(SubgraphIsomorphicDecisionTree):
         weights = self.weights
         W = self.W
 
-        W = self.W
-
         for depth in range(max_depth + 1):
             nodes = [node for node in self.nodes.values() if node.depth == depth]
 

--- a/pysidt/sidt.py
+++ b/pysidt/sidt.py
@@ -583,7 +583,7 @@ def to_dict(obj):
     for attr in attrs:
         val = getattr(obj, attr)
 
-        if callable(val) or val == getattr(obj.__class__(), attr):
+        if not isinstance(val,list) and not isinstance(val,np.ndarray) and not isinstance(val,dict) and (callable(val) or val == getattr(obj.__class__(), attr)):
             continue
 
         try:

--- a/pysidt/sidt.py
+++ b/pysidt/sidt.py
@@ -351,7 +351,7 @@ class SubgraphIsomorphicDecisionTree:
         )
         self.nodes[name] = node
         parent.children.append(node)
-        if grpc:
+        if grpc and all(st.mol.is_subgraph_isomorphic(grpc,generate_initial_map=True,save_order=True) for st in comp):
             frags = name.split("_")
             frags[-1] = "N-" + frags[-1]
             cextname = ""
@@ -1292,7 +1292,8 @@ class MultiEvalSubgraphIsomorphicDecisionTreeRegressor(MultiEvalSubgraphIsomorph
 
         logging.info("adding node {}".format(name))
 
-        if grpc:
+        if grpc and all(st.is_subgraph_isomorphic(grpc,generate_initial_map=True,save_order=True) for st in comp):
+            assert grpc.is_subgraph_isomorphic(parent.group,generate_initial_map=True,save_order=True)
             frags = name.split("_")
             frags[-1] = "N-" + frags[-1]
             cextname = ""
@@ -1687,7 +1688,7 @@ class MultiEvalSubgraphIsomorphicDecisionTreeBinaryClassifier(MultiEvalSubgraphI
 
         logging.info("adding node {}".format(name))
         
-        if grpc:
+        if grpc and all(st.is_subgraph_isomorphic(grpc,generate_initial_map=True,save_order=True) for st in comp):
             class_true = 0
             frags = name.split("_")
             frags[-1] = "N-" + frags[-1]


### PR DESCRIPTION
1) Fixed small bug in atom set handling in extension generation

2) Fixed bug in complementary group handling. Complementary groups that were generated off of bond creation extensions were still considered complementary by node generation even though some were not complementary for the training set. The change checks whether the group is complementary for the training data at that node and only adds it as a complementary node if it is complementary with respect to the associated training data. 

3) Removed a duplicate line of code

4) Small improvement to dictionary generation

5) Add weighting of multi evaluation regressor node selection based on occurrence (along with uncertainty) and make it default. The application I originally developed the algorithm for involved training on data that was distributed differently than the prediction cases. However, in most applications one should assume the training distribution is the same as the prediction distribution. This change doesn't seem to matter so much for larger training sets and does not always improve model performance, but it does make a very significant difference in improving model performance consistency in the <1000 datapoint regime. 