### PR TITLE
New Extension Specifications: Rings, coordination number, sets of specification attributes

### DIFF
--- a/pysidt/extensions.py
+++ b/pysidt/extensions.py
@@ -14,6 +14,8 @@ except:
     from rmgpy.molecule.group import GroupAtom, GroupBond
     from rmgpy.molecule.molecule import Molecule
 
+from pysidt.utils import find_shortest_paths
+
 
 def split_mols(data, newgrp):
     """
@@ -67,6 +69,7 @@ def get_extension_edge(
     r_ncoord=None,
     r_label=None,
     just_reg_dim=False, #determine reg_dims for group only
+    max_ring_gen_size=None,
 ):
     """
     finds the set of all extension groups to parent such that
@@ -116,13 +119,14 @@ def get_extension_edge(
             r_ncoord_full=r_ncoord,
             r_label=r_label,
             n_strucs_min=n_strucs_min,
+            max_ring_gen_size=max_ring_gen_size,
         )
 
         reg_dict = dict()
         ext_inds = []
         for i, (grp2, grpc, name, typ, indc) in enumerate(exts):
             if (
-                typ != "intNewBondExt"
+                typ != "intNewBridgeExt"
                 and typ != "extNewBondExt"
                 and (typ, indc) not in reg_dict.keys()
             ):
@@ -162,7 +166,7 @@ def get_extension_edge(
                     )
 
             elif boo:  # this extension matches all reactions (regularization dim)
-                if typ == "intNewBondExt" or typ == "extNewBondExt":
+                if typ == "intNewBridgeExt" or typ == "extNewBondExt":
                     # these are bond formation extensions, we want to expand these until we get splits
                     ext_inds.append(i)
                 elif typ == "atomExt":
@@ -208,7 +212,7 @@ def get_extension_edge(
             if first_time and not node_children:
                 # parent
                 if (
-                    typr != "intNewBondExt" and typr != "extNewBondExt"
+                    typr != "intNewBridgeExt" and typr != "extNewBondExt"
                 ):  # these dimensions should be regularized
                     if typr == "atomExt":
                         grp.atoms[indcr[0]].reg_dim_atm = list(reg_val)
@@ -229,7 +233,7 @@ def get_extension_edge(
 
             # extensions being sent out
             if (
-                typr != "intNewBondExt" and typr != "extNewBondExt"
+                typr != "intNewBridgeExt" and typr != "extNewBondExt"
             ):  # these dimensions should be regularized
                 for grp2, grpc, name, typ, indc in out_exts[-1]:  # returned groups
                     if typr == "atomExt":
@@ -280,7 +284,7 @@ def get_extension_edge(
         ):  # have to label the regularization dimensions in all relevant groups
             reg_val = reg_dict[(typr, indcr)]
             if (
-                typr != "intNewBondExt" and typr != "extNewBondExt"
+                typr != "intNewBridgeExt" and typr != "extNewBondExt"
             ):  # these dimensions should be regularized
                 for ind2 in ext_inds:  # groups for expansion
                     grp2, grpc, name, typ, indc = exts[ind2]
@@ -384,6 +388,7 @@ def get_extensions(
     atm_ind=None,
     atm_ind2=None,
     n_strucs_min=None,
+    max_ring_gen_size=None,
 ):
     """
     generate all allowed group extensions and their complements
@@ -650,10 +655,10 @@ def get_extensions(
                 specify_external_new_bond_extensions(grp, i, basename, r_bonds, r_label)
             )
             for j, atm2 in enumerate(atoms):
-                if j < i and not grp.has_bond(atm, atm2):
+                if j <= i and not grp.has_bond(atm, atm2):
                     extents.extend(
                         specify_internal_new_bond_extensions(
-                            grp, i, j, n_strucs_min, basename, r_bonds
+                            grp, i, j, n_strucs_min, basename, r_bonds, max_ring_gen_size=max_ring_gen_size,
                         )
                     )
                 elif j < i:
@@ -678,10 +683,10 @@ def get_extensions(
         j = atm_ind2
         atm = atoms[i]
         atm2 = atoms[j]
-        if j < i and not grp.has_bond(atm, atm2):
+        if j <= i and not grp.has_bond(atm, atm2):
             extents.extend(
                 specify_internal_new_bond_extensions(
-                    grp, i, j, n_strucs_min, basename, r_bonds
+                    grp, i, j, n_strucs_min, basename, r_bonds, max_ring_gen_size=max_ring_gen_size,
                 )
             )
         if grp.has_bond(atm, atm2):
@@ -865,10 +870,10 @@ def get_extensions(
 
         extents.extend(specify_external_new_bond_extensions(grp, i, basename, r_bonds, r_label))
         for j, atm2 in enumerate(atoms):
-            if j < i and not grp.has_bond(atm, atm2):
+            if j <= i and not grp.has_bond(atm, atm2):
                 extents.extend(
                     specify_internal_new_bond_extensions(
-                        grp, i, j, n_strucs_min, basename, r_bonds
+                        grp, i, j, n_strucs_min, basename, r_bonds, max_ring_gen_size=max_ring_gen_size,
                     )
                 )
             elif j < i:
@@ -1190,20 +1195,30 @@ def specify_ncoord_extensions(grp, i, basename, r_ncoord, r_ncoord_full):
 
     return grps
 
-def specify_internal_new_bond_extensions(grp, i, j, n_strucs_min, basename, r_bonds):
+def specify_internal_new_bond_extensions(grp, i, j, n_strucs_min, basename, r_bonds, max_ring_gen_size=None):
     """
     generates extensions for creation of a bond (of undefined order)
     between two atoms indexed i,j that already exist in the group and are unbonded
     """
     # cython.declare(newgrp=Group)
-
+    if i == j:
+        if max_ring_gen_size is None:
+            return []
+        pathlen = 1
+    else:
+        paths = find_shortest_paths(grp.atoms[i],grp.atoms[j])
+        if paths is None:
+            pathlen = None
+        else:
+            pathlen = len(paths[0])
+    
+    if pathlen is None and n_strucs_min == len(grp.split()): #internal bridge will reduce below minimum number of independent structures
+        return []
+    
     label_list = []
-
-    newgrp = deepcopy(grp)
-    newgrp.add_bond(GroupBond(newgrp.atoms[i], newgrp.atoms[j], r_bonds))
-
-    atom_type_i = newgrp.atoms[i].atomtype
-    atom_type_j = newgrp.atoms[j].atomtype
+        
+    atom_type_i = grp.atoms[i].atomtype
+    atom_type_j = grp.atoms[j].atomtype
 
     if len(atom_type_i) > 1:
         atom_type_i_str = ""
@@ -1225,28 +1240,61 @@ def specify_internal_new_bond_extensions(grp, i, j, n_strucs_min, basename, r_bo
         atom_type_j_str = ""
     else:
         atom_type_j_str = atom_type_j[0].label
+        
+    if max_ring_gen_size is None: #just internal bond extensions
+        newgrp = deepcopy(grp)
+        newgrp.add_bond(GroupBond(newgrp.atoms[i], newgrp.atoms[j], r_bonds))
 
-    if (
-        len(newgrp.split()) < n_strucs_min
-    ):  # if this formed a bond between two seperate groups in the
-        return []
-    else:
         return [
-            (
-                newgrp,
-                None,
-                basename
-                + "_Int-"
-                + str(i + 1)
-                + atom_type_i_str
-                + "-"
-                + str(j + 1)
-                + atom_type_j_str,
-                "intNewBondExt",
-                (i, j),
-            )
-        ]
-
+                (
+                    newgrp,
+                    None,
+                    basename
+                    + "_Int-"
+                    + str(i + 1)
+                    + atom_type_i_str
+                    + "-"
+                    + str(j + 1)
+                    + atom_type_j_str
+                    + "-Br0",
+                    "intNewBridgeExt",
+                    (i, j),
+                )
+            ]
+    else:
+        grps = []
+        for bridgelen in range(max_ring_gen_size-pathlen+1): #includes bridgelen == 0
+            if i == j and bridgelen < 2: #this is no change from the original group or external bond creation
+                continue
+            newgrp = deepcopy(grp)
+            tail_atom = newgrp.atoms[i]
+            head_atom = newgrp.atoms[j]
+            for k in range(bridgelen): #create first ring
+                newatm = GroupAtom([ATOMTYPES['R!H']])
+                newgrp.add_atom(newatm)
+                bd = GroupBond(tail_atom,newatm,order=r_bonds)
+                newgrp.add_bond(bd)
+                tail_atom = newatm
+            else:
+                bd = GroupBond(tail_atom,head_atom,order=r_bonds)
+                newgrp.add_bond(bd)
+            
+            grps.append((
+                    newgrp,
+                    None,
+                    basename
+                    + "_Int-"
+                    + str(i + 1)
+                    + atom_type_i_str
+                    + "-"
+                    + str(j + 1)
+                    + atom_type_j_str
+                    + "-Br"+str(bridgelen),
+                    "intNewBridgeExt",
+                    (i, j),
+                ))
+    
+    return grps    
 
 def specify_external_new_bond_extensions(grp, i, basename, r_bonds, r_label):
     """

--- a/pysidt/extensions.py
+++ b/pysidt/extensions.py
@@ -25,6 +25,9 @@ def split_mols(data, newgrp):
     and a list of the indices of all of the reactions
     associated with the new group
     """
+    if len(data) == 0:
+        return [],[]
+    
     new = []
     comp = []
 

--- a/pysidt/extensions.py
+++ b/pysidt/extensions.py
@@ -62,6 +62,7 @@ def get_extension_edge(
     r_site=None,
     r_morph=None,
     r_ncoord=None,
+    r_label=None,
     just_reg_dim=False, #determine reg_dims for group only
 ):
     """
@@ -87,6 +88,8 @@ def get_extension_edge(
         r_site = []
     if r_morph is None:
         r_morph = []
+    if r_label is None:
+        r_label = None
 
     out_exts = [[]]
     grps = [[group]]
@@ -108,6 +111,7 @@ def get_extension_edge(
             r_site_full=r_site,
             r_morph_full=r_morph,
             r_ncoord_full=r_ncoord,
+            r_label=r_label,
             n_strucs_min=n_strucs_min,
         )
 
@@ -372,6 +376,7 @@ def get_extensions(
     r_site_full=[],
     r_morph_full=[],
     r_ncoord_full=[],
+    r_label=[],
     basename="",
     atm_ind=None,
     atm_ind2=None,
@@ -422,6 +427,9 @@ def get_extensions(
             r_ncoord = [x for y in r_ncoord_full for x in y]
         else:
             r_ncoord = r_ncoord_full[:]
+    
+    if r_label == []:
+        r_label = ['']
     
     # generate appropriate r and r!H
     if r is None:
@@ -636,7 +644,7 @@ def get_extensions(
                 extents.extend(specify_ring_extensions(grp, i, basename))
 
             extents.extend(
-                specify_external_new_bond_extensions(grp, i, basename, r_bonds)
+                specify_external_new_bond_extensions(grp, i, basename, r_bonds, r_label)
             )
             for j, atm2 in enumerate(atoms):
                 if j < i and not grp.has_bond(atm, atm2):
@@ -852,7 +860,7 @@ def get_extensions(
         if not atm.reg_dim_r[0] and "inRing" not in atm.props:
             extents.extend(specify_ring_extensions(grp, i, basename))
 
-        extents.extend(specify_external_new_bond_extensions(grp, i, basename, r_bonds))
+        extents.extend(specify_external_new_bond_extensions(grp, i, basename, r_bonds, r_label))
         for j, atm2 in enumerate(atoms):
             if j < i and not grp.has_bond(atm, atm2):
                 extents.extend(
@@ -1237,42 +1245,43 @@ def specify_internal_new_bond_extensions(grp, i, j, n_strucs_min, basename, r_bo
         ]
 
 
-def specify_external_new_bond_extensions(grp, i, basename, r_bonds):
+def specify_external_new_bond_extensions(grp, i, basename, r_bonds, r_label):
     """
     generates extensions for the creation of a bond (of undefined order) between
     an atom and a new atom that is not H
     """
     # cython.declare(ga=GroupAtom, newgrp=Group, j=int)
-
     label_list = []
+    grps = []
+    for alabel in r_label:
+        ga = GroupAtom([ATOMTYPES["Rx!H"]])
+        ga.label = alabel
+        newgrp = deepcopy(grp)
+        newgrp.add_atom(ga)
+        j = newgrp.atoms.index(ga)
+        newgrp.add_bond(GroupBond(newgrp.atoms[i], newgrp.atoms[j], r_bonds))
+        atom_type = newgrp.atoms[i].atomtype
+        if len(atom_type) > 1:
+            atom_type_str = ""
+            for k in atom_type:
+                label_list.append(k.label)
+            for p in sorted(label_list):
+                atom_type_str += p
+        elif len(atom_type) == 0:
+            atom_type_str = ""
+        else:
+            atom_type_str = atom_type[0].label
 
-    ga = GroupAtom([ATOMTYPES["Rx!H"]])
-    newgrp = deepcopy(grp)
-    newgrp.add_atom(ga)
-    j = newgrp.atoms.index(ga)
-    newgrp.add_bond(GroupBond(newgrp.atoms[i], newgrp.atoms[j], r_bonds))
-    atom_type = newgrp.atoms[i].atomtype
-    if len(atom_type) > 1:
-        atom_type_str = ""
-        for k in atom_type:
-            label_list.append(k.label)
-        for p in sorted(label_list):
-            atom_type_str += p
-    elif len(atom_type) == 0:
-        atom_type_str = ""
-    else:
-        atom_type_str = atom_type[0].label
-
-    return [
-        (
-            newgrp,
-            None,
-            basename + "_Ext-" + str(i + 1) + atom_type_str + "-R",
-            "extNewBondExt",
-            (len(newgrp.atoms) - 1,),
+        grps.append(
+            (
+                newgrp,
+                None,
+                basename + "_Ext-" + str(i + 1) + atom_type_str + "-R" + alabel,
+                "extNewBondExt",
+                (len(newgrp.atoms) - 1,),
+            )
         )
-    ]
-
+    return grps
 
 def specify_bond_extensions(grp, i, j, basename, r_bonds, r_bonds_full):
     """

--- a/pysidt/extensions.py
+++ b/pysidt/extensions.py
@@ -61,6 +61,7 @@ def get_extension_edge(
     r_un=None,
     r_site=None,
     r_morph=None,
+    r_ncoord=None,
     just_reg_dim=False, #determine reg_dims for group only
 ):
     """
@@ -106,6 +107,7 @@ def get_extension_edge(
             r_un_full=r_un,
             r_site_full=r_site,
             r_morph_full=r_morph,
+            r_ncoord_full=r_ncoord,
             n_strucs_min=n_strucs_min,
         )
 
@@ -147,6 +149,10 @@ def get_extension_edge(
                     reg_dict[(typ, indc)][0].extend(
                         grp2.get_bond(grp2.atoms[indc[0]], grp2.atoms[indc[1]]).order
                     )
+                elif typ == "coordExt":
+                    reg_dict[(typ, indc)][0].extend(
+                        grp2.atoms[indc[0]].props["Ncoord"]
+                    )
 
             elif boo:  # this extension matches all reactions (regularization dim)
                 if typ == "intNewBondExt" or typ == "extNewBondExt":
@@ -168,6 +174,13 @@ def get_extension_edge(
                     )
                     reg_dict[(typ, indc)][1].extend(
                         grp2.get_bond(grp2.atoms[indc[0]], grp2.atoms[indc[1]]).order
+                    )
+                elif typ == "coordExt":
+                    reg_dict[(typ, indc)][0].extend(
+                        grp2.atoms[indc[0]].props["Ncoord"]
+                    )
+                    reg_dict[(typ, indc)][1].extend(
+                        grp2.atoms[indc[0]].props["Ncoord"]
                     )
                 elif typ == "ringExt":
                     reg_dict[(typ, indc)][1].append(True)
@@ -198,6 +211,8 @@ def get_extension_edge(
                         grp.atoms[indcr[0]].reg_dim_site = list(reg_val)
                     elif typr == "morphExt":
                         grp.atoms[indcr[0]].reg_dim_morphology = list(reg_val)
+                    elif typr == "coordExt":
+                        grp.atoms[indcr[0]].reg_dim_ncoord = list(reg_val)
                     elif typr == "ringExt":
                         grp.atoms[indcr[0]].reg_dim_r = list(reg_val)
                     elif typr == "bondExt":
@@ -226,6 +241,10 @@ def get_extension_edge(
                         grp2.atoms[indcr[0]].reg_dim_morphology = list(reg_val)
                         if grpc:
                             grpc.atoms[indcr[0]].reg_dim_morphology = list(reg_val)
+                    elif typr == "coordExt":
+                        grp2.atoms[indcr[0]].reg_dim_ncoord = list(reg_val)
+                        if grpc:
+                            grpc.atoms[indcr[0]].reg_dim_ncoord = list(reg_val)
                     elif typr == "ringExt":
                         grp2.atoms[indcr[0]].reg_dim_r = list(reg_val)
                         if grpc:
@@ -274,6 +293,10 @@ def get_extension_edge(
                         grp2.atoms[indcr[0]].reg_dim_morphology = list(reg_val)
                         if grpc:
                             grpc.atoms[indcr[0]].reg_dim_morphology = list(reg_val)
+                    elif typr == "coordExt":
+                        grp2.atoms[indcr[0]].reg_dim_ncoord = list(reg_val)
+                        if grpc:
+                            grpc.atoms[indcr[0]].reg_dim_ncoord = list(reg_val)
                     elif typr == "ringExt":
                         grp2.atoms[indcr[0]].reg_dim_r = list(reg_val)
                         if grpc:
@@ -348,6 +371,7 @@ def get_extensions(
     r_un_full=[0, 1, 2, 3],
     r_site_full=[],
     r_morph_full=[],
+    r_ncoord_full=[],
     basename="",
     atm_ind=None,
     atm_ind2=None,
@@ -392,6 +416,12 @@ def get_extensions(
             r_morph = [x for y in r_morph_full for x in y]
         else:
             r_morph = r_morph_full[:]
+    
+    if r_ncoord_full:
+        if isinstance(r_ncoord_full[0],list):
+            r_ncoord = [x for y in r_ncoord_full for x in y]
+        else:
+            r_ncoord = r_ncoord_full[:]
     
     # generate appropriate r and r!H
     if r is None:
@@ -569,6 +599,37 @@ def get_extensions(
                                     r_morph_full,
                                 )
                             )
+            if r_ncoord_full:
+                if not atm.reg_dim_ncoord[0]:
+                    if "Ncoord" not in atm.props.keys() or len(atm.props["Ncoord"]) != 1:
+                        if "Ncoord" not in atm.props.keys() or len(atm.props["Ncoord"]) == 0:
+                            extents.extend(
+                                specify_ncoord_extensions(grp, i, basename, r_ncoord, r_ncoord_full)
+                            )
+                        else:
+                            extents.extend(
+                                specify_ncoord_extensions(
+                                    grp, i, basename, atm.props["Ncoord"], r_ncoord_full
+                                )
+                            )
+                else:
+                    if "Ncoord" not in atm.props.keys() or (len(atm.props["Ncoord"]) != 1 and len(atm.reg_dim_ncoord[0]) != 1):
+                        if "Ncoord" not in atm.props.keys() or len(atm.props["Ncoord"]) == 0:
+                            extents.extend(
+                                specify_ncoord_extensions(
+                                    grp, i, basename, atm.reg_dim_ncoord[0], r_ncoord_full
+                                )
+                            )
+                        else:
+                            extents.extend(
+                                specify_ncoord_extensions(
+                                    grp,
+                                    i,
+                                    basename,
+                                    list(
+                                        set(atm.props["Ncoord"]) & set(atm.reg_dim_ncoord[0])
+                                    ),
+                                    r_ncoord_full,
                                 )
                             )
             if not atm.reg_dim_r[0] and "inRing" not in atm.props:
@@ -761,6 +822,31 @@ def get_extensions(
                                 r_morph_full,
                             )
                         )
+        if r_ncoord_full:
+            if not atm.reg_dim_ncoord:
+                if "Ncoord" not in atm.props.keys() or len(atm.props["Ncoord"]) != 1:
+                    if "Ncoord" not in atm.props.keys() or len(atm.props["Ncoord"]) == 0:
+                        extents.extend(specify_ncoord_extensions(grp, i, basename, r_ncoord, r_ncoord_full))
+                    else:
+                        extents.extend(
+                            specify_ncoord_extensions(
+                                grp, i, basename, atm.props["Ncoord"], r_ncoord_full
+                            )
+                        )
+            else:
+                if "Ncoord" not in atm.props.keys() or (len(atm.props["Ncoord"]) != 1 and len(atm.reg_dim_ncoord[0]) != 1):
+                    if "Ncoord" not in atm.props.keys() or len(atm.props["Ncoord"]) == 0:
+                        extents.extend(
+                            specify_ncoord_extensions(grp, i, basename, atm.reg_dim_ncoord[0], r_ncoord_full)
+                        )
+                    else:
+                        extents.extend(
+                            specify_ncoord_extensions(
+                                grp,
+                                i,
+                                basename,
+                                list(set(atm.props["Ncoord"]) & set(atm.reg_dim_ncoord[0])),
+                                r_ncoord_full,
                             )
                         )
         if not atm.reg_dim_r[0] and "inRing" not in atm.props:
@@ -1048,6 +1134,50 @@ def specify_morphology_extensions(grp, i, basename, r_morph, r_morph_full):
 
     return grps
 
+def specify_ncoord_extensions(grp, i, basename, r_ncoord, r_ncoord_full):
+    """
+    generates extensions for specification of the number of electrons on a given atom
+    """
+
+    grps = []
+    label_list = []
+
+    Rset = set(r_ncoord)
+    if isinstance(r_ncoord_full,list):
+        r_spc_ncoord_full = [[y for y in x if y in r_ncoord] for x in r_ncoord_full]
+        if len(r_spc_ncoord_full) == 1:
+            r_spc_ncoord_full = [[x] for x in r_spc_ncoord_full[0]]
+        else:
+            r_spc_ncoord_full += [[x] for x in sum(r_spc_ncoord_full,[]) if [x] not in r_spc_ncoord_full]
+    else:
+        r_spc_ncoord_full = [[x] for x in r_ncoord_full if x in r_ncoord]
+    for item in r_spc_ncoord_full:
+        g = deepcopy(grp)
+        grpc = deepcopy(grp)
+        g.atoms[i].props["Ncoord"] = item
+        grpc.atoms[i].props["Ncoord"] = list(Rset - set(item))
+
+        if len(grpc.atoms[i].props["Ncoord"]) == 0:
+            grpc = None
+
+        atom_type = g.atoms[i].atomtype
+
+        if len(atom_type) > 1:
+            atom_type_str = ""
+            for k in atom_type:
+                label_list.append(k.label)
+            for p in sorted(label_list):
+                atom_type_str += p
+        elif len(atom_type) == 0:
+            atom_type_str = ""
+        else:
+            atom_type_str = atom_type[0].label
+
+        grps.append(
+            (g, grpc, basename + "_" + str(i + 1) + "-n" + "".join([str(x) for x in item]), "coordExt", (i,))
+        )
+
+    return grps
 
 def specify_internal_new_bond_extensions(grp, i, j, n_strucs_min, basename, r_bonds):
     """

--- a/pysidt/extensions.py
+++ b/pysidt/extensions.py
@@ -61,6 +61,7 @@ def get_extension_edge(
     r_un=None,
     r_site=None,
     r_morph=None,
+    just_reg_dim=False, #determine reg_dims for group only
 ):
     """
     finds the set of all extension groups to parent such that
@@ -296,6 +297,9 @@ def get_extension_edge(
         grps[iter].pop()
         names.pop()
 
+        if just_reg_dim:
+            return True,None
+        
         for ind in ext_inds:  # collect the groups to be expanded
             grpr, grpcr, namer, typr, indcr = exts[ind]
             if len(grps) == iter + 1:

--- a/pysidt/extensions.py
+++ b/pysidt/extensions.py
@@ -101,11 +101,11 @@ def get_extension_edge(
         exts = get_extensions(
             grp,
             basename=names[-1],
-            r=r,
-            r_bonds=r_bonds,
-            r_un=r_un,
-            r_site=r_site,
-            r_morph=r_morph,
+            r_full=r,
+            r_bonds_full=r_bonds,
+            r_un_full=r_un,
+            r_site_full=r_site,
+            r_morph_full=r_morph,
             n_strucs_min=n_strucs_min,
         )
 
@@ -343,11 +343,11 @@ def get_extension_edge(
 
 def get_extensions(
     grp,
-    r=None,
-    r_bonds=[1, 2, 3, 1.5, 4],
-    r_un=[0, 1, 2, 3],
-    r_site=[],
-    r_morph=[],
+    r_full=None,
+    r_bonds_full=[1, 2, 3, 1.5, 4],
+    r_un_full=[0, 1, 2, 3],
+    r_site_full=[],
+    r_morph_full=[],
     basename="",
     atm_ind=None,
     atm_ind2=None,
@@ -364,6 +364,35 @@ def get_extensions(
     if n_strucs_min is None:
         n_strucs_min = len(grp.split())
 
+    if isinstance(r_full[0],list):
+        r = [x for y in r_full for x in y]
+    else:
+        r = r_full[:]
+    
+    if r_bonds_full:
+        if isinstance(r_bonds_full[0],list):
+            r_bonds = [x for y in r_bonds_full for x in y]
+        else:
+            r_bonds = r_bonds_full[:]
+    
+    if r_un_full:
+        if isinstance(r_un_full[0],list):
+            r_un = [x for y in r_un_full for x in y]
+        else:
+            r_un = r_un_full[:]
+    
+    if r_site_full:
+        if isinstance(r_site_full[0],list):
+            r_site = [x for y in r_site_full for x in y]
+        else:
+            r_site = r_site_full[:]
+    
+    if r_morph_full:
+        if isinstance(r_morph_full[0],list):
+            r_morph = [x for y in r_morph_full for x in y]
+        else:
+            r_morph = r_morph_full[:]
+    
     # generate appropriate r and r!H
     if r is None:
         r = bde_elements  # set of possible r elements/atoms
@@ -400,34 +429,34 @@ def get_extensions(
                 if len(typ) == 1:
                     if typ[0].label == "R":
                         extents.extend(
-                            specify_atom_extensions(grp, i, basename, R)
+                            specify_atom_extensions(grp, i, basename, R, r_full)
                         )  # specify types of atoms
                     elif typ[0].label == "R!H":
-                        extents.extend(specify_atom_extensions(grp, i, basename, RnH))
+                        extents.extend(specify_atom_extensions(grp, i, basename, RnH, r_full))
                     elif typ[0].label == "Rx":
-                        extents.extend(specify_atom_extensions(grp, i, basename, r))
+                        extents.extend(specify_atom_extensions(grp, i, basename, r, r_full))
                     elif typ[0].label == "Rx!H":
-                        extents.extend(specify_atom_extensions(grp, i, basename, RxnH))
+                        extents.extend(specify_atom_extensions(grp, i, basename, RxnH, r_full))
                 else:
-                    extents.extend(specify_atom_extensions(grp, i, basename, typ))
+                    extents.extend(specify_atom_extensions(grp, i, basename, typ, r_full))
             else:
                 if len(typ) == 1:
                     if typ[0].label == "R":
                         extents.extend(
                             specify_atom_extensions(
-                                grp, i, basename, atm.reg_dim_atm[0]
+                                grp, i, basename, atm.reg_dim_atm[0], r_full
                             )
                         )  # specify types of atoms
                     elif typ[0].label == "R!H":
                         extents.extend(
                             specify_atom_extensions(
-                                grp, i, basename, list(set(atm.reg_dim_atm[0]) & set(RnH))
+                                grp, i, basename, list(set(atm.reg_dim_atm[0]) & set(RnH)), r_full
                             )
                         )
                     elif typ[0].label == "Rx":
                         extents.extend(
                             specify_atom_extensions(
-                                grp, i, basename, list(set(atm.reg_dim_atm[0]) & set(r))
+                                grp, i, basename, list(set(atm.reg_dim_atm[0]) & set(r)), r_full
                             )
                         )
                     elif typ[0].label == "Rx!H":
@@ -436,26 +465,26 @@ def get_extensions(
                                 grp,
                                 i,
                                 basename,
-                                list(set(atm.reg_dim_atm[0]) & set(RxnH)),
+                                list(set(atm.reg_dim_atm[0]) & set(RxnH)), r_full
                             )
                         )
 
                 else:
                     extents.extend(
                         specify_atom_extensions(
-                            grp, i, basename, list(set(typ) & set(atm.reg_dim_atm[0]))
+                            grp, i, basename, list(set(typ) & set(atm.reg_dim_atm[0])), r_full
                         )
                     )
             if not atm.reg_dim_u[0]:
                 if len(atm.radical_electrons) != 1:
                     if len(atm.radical_electrons) == 0:
                         extents.extend(
-                            specify_unpaired_extensions(grp, i, basename, r_un)
+                            specify_unpaired_extensions(grp, i, basename, r_un, r_un_full)
                         )
                     else:
                         extents.extend(
                             specify_unpaired_extensions(
-                                grp, i, basename, atm.radical_electrons
+                                grp, i, basename, atm.radical_electrons, r_un_full
                             )
                         )
             else:
@@ -463,7 +492,7 @@ def get_extensions(
                     if len(atm.radical_electrons) == 0:
                         extents.extend(
                             specify_unpaired_extensions(
-                                grp, i, basename, atm.reg_dim_u[0]
+                                grp, i, basename, atm.reg_dim_u[0], r_un_full
                             )
                         )
                     else:
@@ -475,25 +504,26 @@ def get_extensions(
                                 list(
                                     set(atm.radical_electrons) & set(atm.reg_dim_u[0])
                                 ),
+                                r_un_full,
                             )
                         )
-            if r_site:
+            if r_site_full:
                 if not atm.reg_dim_site[0]:
                     if len(atm.site) != 1:
                         if len(atm.site) == 0:
                             extents.extend(
-                                specify_site_extensions(grp, i, basename, r_site)
+                                specify_site_extensions(grp, i, basename, r_site, r_site_full)
                             )
                         else:
                             extents.extend(
-                                specify_site_extensions(grp, i, basename, atm.site)
+                                specify_site_extensions(grp, i, basename, atm.site, r_site_full)
                             )
                 else:
                     if len(atm.site) != 1 and len(atm.reg_dim_site[0]) != 1:
                         if len(atm.site) == 0:
                             extents.extend(
                                 specify_site_extensions(
-                                    grp, i, basename, atm.reg_dim_site[0]
+                                    grp, i, basename, atm.reg_dim_site[0], r_site_full
                                 )
                             )
                         else:
@@ -502,20 +532,20 @@ def get_extensions(
                                     grp,
                                     i,
                                     basename,
-                                    list(set(atm.site) & set(atm.reg_dim_site[0])),
+                                    list(set(atm.site) & set(atm.reg_dim_site[0])), r_site_full
                                 )
                             )
-            if r_morph:
+            if r_morph_full:
                 if not atm.reg_dim_morphology[0]:
                     if len(atm.morphology) != 1:
                         if len(atm.morphology) == 0:
                             extents.extend(
-                                specify_morphology_extensions(grp, i, basename, r_morph)
+                                specify_morphology_extensions(grp, i, basename, r_morph, r_morph_full)
                             )
                         else:
                             extents.extend(
                                 specify_morphology_extensions(
-                                    grp, i, basename, atm.morphology
+                                    grp, i, basename, atm.morphology, r_morph_full
                                 )
                             )
                 else:
@@ -523,7 +553,7 @@ def get_extensions(
                         if len(atm.morphology) == 0:
                             extents.extend(
                                 specify_morphology_extensions(
-                                    grp, i, basename, atm.reg_dim_morphology[0]
+                                    grp, i, basename, atm.reg_dim_morphology[0], r_morph_full
                                 )
                             )
                         else:
@@ -536,6 +566,9 @@ def get_extensions(
                                         set(atm.morphology)
                                         & set(atm.reg_dim_morphology[0])
                                     ),
+                                    r_morph_full,
+                                )
+                            )
                                 )
                             )
             if not atm.reg_dim_r[0] and "inRing" not in atm.props:
@@ -555,7 +588,7 @@ def get_extensions(
                     bd = grp.get_bond(atm, atm2)
                     if len(bd.order) > 1 and not bd.reg_dim[0]:
                         extents.extend(
-                            specify_bond_extensions(grp, i, j, basename, bd.order)
+                            specify_bond_extensions(grp, i, j, basename, bd.order, r_bonds_full)
                         )
                     elif (
                         len(bd.order) > 1
@@ -563,7 +596,7 @@ def get_extensions(
                         and len(bd.reg_dim[0]) > len(bd.reg_dim[1])
                     ):
                         extents.extend(
-                            specify_bond_extensions(grp, i, j, basename, bd.reg_dim[0])
+                            specify_bond_extensions(grp, i, j, basename, bd.reg_dim[0], r_bonds_full)
                         )
 
     elif (
@@ -582,14 +615,14 @@ def get_extensions(
         if grp.has_bond(atm, atm2):
             bd = grp.get_bond(atm, atm2)
             if len(bd.order) > 1 and not bd.reg_dim[0]:
-                extents.extend(specify_bond_extensions(grp, i, j, basename, bd.order))
+                extents.extend(specify_bond_extensions(grp, i, j, basename, bd.order, r_bonds_full))
             elif (
                 len(bd.order) > 1
                 and len(bd.reg_dim[0]) > 1
                 and len(bd.reg_dim[0]) > len(bd.reg_dim[1])
             ):
                 extents.extend(
-                    specify_bond_extensions(grp, i, j, basename, bd.reg_dim[0])
+                    specify_bond_extensions(grp, i, j, basename, bd.reg_dim[0], r_bonds_full)
                 )
 
     elif atm_ind is not None:  # look at the atom at atm_ind
@@ -603,58 +636,58 @@ def get_extensions(
                         specify_atom_extensions(grp, i, basename, R)
                     )  # specify types of atoms
                 elif typ[0].label == "R!H":
-                    extents.extend(specify_atom_extensions(grp, i, basename, RnH))
+                    extents.extend(specify_atom_extensions(grp, i, basename, RnH, r_full))
                 elif typ[0].label == "Rx":
-                    extents.extend(specify_atom_extensions(grp, i, basename, r))
+                    extents.extend(specify_atom_extensions(grp, i, basename, r, r_full))
                 elif typ[0].label == "Rx!H":
-                    extents.extend(specify_atom_extensions(grp, i, basename, RxnH))
+                    extents.extend(specify_atom_extensions(grp, i, basename, RxnH, r_full))
             else:
-                extents.extend(specify_atom_extensions(grp, i, basename, typ))
+                extents.extend(specify_atom_extensions(grp, i, basename, typ, r_full))
         else:
             if len(typ) == 1:
                 if typ[0].label == "R":
                     extents.extend(
-                        specify_atom_extensions(grp, i, basename, atm.reg_dim_atm[0])
+                        specify_atom_extensions(grp, i, basename, atm.reg_dim_atm[0], r_full)
                     )  # specify types of atoms
                 elif typ[0].label == "R!H":
                     extents.extend(
                         specify_atom_extensions(
-                            grp, i, basename, list(set(atm.reg_dim_atm[0]) & set(RnH))
+                            grp, i, basename, list(set(atm.reg_dim_atm[0]) & set(RnH)), r_full
                         )
                     )
                 elif typ[0].label == "Rx":
                     extents.extend(
                         specify_atom_extensions(
-                            grp, i, basename, list(set(atm.reg_dim_atm[0]) & set(r))
+                            grp, i, basename, list(set(atm.reg_dim_atm[0]) & set(r)), r_full
                         )
                     )
                 elif typ[0].label == "Rx!H":
                     extents.extend(
                         specify_atom_extensions(
-                            grp, i, basename, list(set(atm.reg_dim_atm[0]) & set(RxnH))
+                            grp, i, basename, list(set(atm.reg_dim_atm[0]) & set(RxnH)), r_full
                         )
                     )
             else:
                 extents.extend(
                     specify_atom_extensions(
-                        grp, i, basename, list(set(typ) & set(atm.reg_dim_atm[0]))
+                        grp, i, basename, list(set(typ) & set(atm.reg_dim_atm[0])), r_full
                     )
                 )
         if not atm.reg_dim_u:
             if len(atm.radical_electrons) != 1:
                 if len(atm.radical_electrons) == 0:
-                    extents.extend(specify_unpaired_extensions(grp, i, basename, r_un))
+                    extents.extend(specify_unpaired_extensions(grp, i, basename, r_un, r_un_full))
                 else:
                     extents.extend(
                         specify_unpaired_extensions(
-                            grp, i, basename, atm.radical_electrons
+                            grp, i, basename, atm.radical_electrons, r_un_full
                         )
                     )
         else:
             if len(atm.radical_electrons) != 1 and len(atm.reg_dim_u[0]) != 1:
                 if len(atm.radical_electrons) == 0:
                     extents.extend(
-                        specify_unpaired_extensions(grp, i, basename, atm.reg_dim_u[0])
+                        specify_unpaired_extensions(grp, i, basename, atm.reg_dim_u[0], r_un_full)
                     )
                 else:
                     extents.extend(
@@ -663,25 +696,26 @@ def get_extensions(
                             i,
                             basename,
                             list(set(atm.radical_electrons) & set(atm.reg_dim_u[0])),
+                            r_un_full,
                         )
                     )
-        if r_site:
+        if r_site_full:
             if not atm.reg_dim_site:
                 if len(atm.site) != 1:
                     if len(atm.site) == 0:
                         extents.extend(
-                            specify_site_extensions(grp, i, basename, r_site)
+                            specify_site_extensions(grp, i, basename, r_site, r_site_full)
                         )
                     else:
                         extents.extend(
-                            specify_site_extensions(grp, i, basename, atm.site)
+                            specify_site_extensions(grp, i, basename, atm.site, r_site_full)
                         )
             else:
                 if len(atm.site) != 1 and len(atm.reg_dim_site[0]) != 1:
                     if len(atm.site) == 0:
                         extents.extend(
                             specify_site_extensions(
-                                grp, i, basename, atm.reg_dim_site[0]
+                                grp, i, basename, atm.reg_dim_site[0], r_site_full
                             )
                         )
                     else:
@@ -691,19 +725,20 @@ def get_extensions(
                                 i,
                                 basename,
                                 list(set(atm.site) & set(atm.reg_dim_site[0])),
+                                r_site_full,
                             )
                         )
-        if r_morph:
+        if r_morph_full:
             if not atm.reg_dim_morphology:
                 if len(atm.morphology) != 1:
                     if len(atm.morphology) == 0:
                         extents.extend(
-                            specify_morphology_extensions(grp, i, basename, r_morph)
+                            specify_morphology_extensions(grp, i, basename, r_morph, r_morph_full)
                         )
                     else:
                         extents.extend(
                             specify_morphology_extensions(
-                                grp, i, basename, atm.morphology
+                                grp, i, basename, atm.morphology, r_morph_full
                             )
                         )
             else:
@@ -711,7 +746,7 @@ def get_extensions(
                     if len(atm.morphology) == 0:
                         extents.extend(
                             specify_morphology_extensions(
-                                grp, i, basename, atm.reg_dim_morphology[0]
+                                grp, i, basename, atm.reg_dim_morphology[0], r_morph_full
                             )
                         )
                     else:
@@ -723,6 +758,9 @@ def get_extensions(
                                 list(
                                     set(atm.morphology) & set(atm.reg_dim_morphology[0])
                                 ),
+                                r_morph_full,
+                            )
+                        )
                             )
                         )
         if not atm.reg_dim_r[0] and "inRing" not in atm.props:
@@ -740,7 +778,7 @@ def get_extensions(
                 bd = grp.get_bond(atm, atm2)
                 if len(bd.order) > 1 and not bd.reg_dim:
                     extents.extend(
-                        specify_bond_extensions(grp, i, j, basename, bd.order)
+                        specify_bond_extensions(grp, i, j, basename, bd.order, r_bonds_full)
                     )
                 elif (
                     len(bd.order) > 1
@@ -748,7 +786,7 @@ def get_extensions(
                     and len(bd.reg_dim[0]) > len(bd.reg_dim[1])
                 ):
                     extents.extend(
-                        specify_bond_extensions(grp, i, j, basename, bd.reg_dim[0])
+                        specify_bond_extensions(grp, i, j, basename, bd.reg_dim[0], r_bonds_full)
                     )
 
     else:
@@ -762,7 +800,7 @@ def get_extensions(
     return extents
 
 
-def specify_atom_extensions(grp, i, basename, r):
+def specify_atom_extensions(grp, i, basename, r, r_full):
     """
     generates extensions for specification of the type of atom defined by a given atomtype
     or set of atomtypes
@@ -771,12 +809,20 @@ def specify_atom_extensions(grp, i, basename, r):
 
     grps = []
     Rset = set(r)
-    for item in r:
-        grp = deepcopy(grp)
+    if isinstance(r_full[0],list):
+        r_spc_full = [[y for y in x if y in r] for x in r_full]
+        if len(r_spc_full) == 1:
+            r_spc_full = [[x] for x in r_spc_full[0]]
+        else:
+            r_spc_full += [[x] for x in sum(r_spc_full,[]) if [x] not in r_spc_full]
+    else:
+        r_spc_full = [[x] for x in r_full if x in r]
+    for item in r_spc_full:
+        g = deepcopy(grp)
         grpc = deepcopy(grp)
-        old_atom_type = grp.atoms[i].atomtype
-        grp.atoms[i].atomtype = [item]
-        grpc.atoms[i].atomtype = list(Rset - {item})
+        old_atom_type = g.atoms[i].atomtype
+        g.atoms[i].atomtype = item
+        grpc.atoms[i].atomtype = list(Rset - set(item))
 
         if len(grpc.atoms[i].atomtype) == 0:
             grpc = None
@@ -795,9 +841,9 @@ def specify_atom_extensions(grp, i, basename, r):
 
         grps.append(
             (
-                grp,
+                g,
                 grpc,
-                basename + "_" + str(i + 1) + old_atom_type_str + "->" + item.label,
+                basename + "_" + str(i + 1) + old_atom_type_str + "->" + "".join([x.label for x in item]),
                 "atomExt",
                 (i,),
             )
@@ -816,12 +862,12 @@ def specify_ring_extensions(grp, i, basename):
     grps = []
     label_list = []
 
-    grp = deepcopy(grp)
+    g = deepcopy(grp)
     grpc = deepcopy(grp)
-    grp.atoms[i].props["inRing"] = True
+    g.atoms[i].props["inRing"] = True
     grpc.atoms[i].props["inRing"] = False
 
-    atom_type = grp.atoms[i].atomtype
+    atom_type = g.atoms[i].atomtype
 
     if len(atom_type) > 1:
         atom_type_str = ""
@@ -836,7 +882,7 @@ def specify_ring_extensions(grp, i, basename):
 
     grps.append(
         (
-            grp,
+            g,
             grpc,
             basename + "_" + str(i + 1) + atom_type_str + "-inRing",
             "ringExt",
@@ -847,7 +893,7 @@ def specify_ring_extensions(grp, i, basename):
     return grps
 
 
-def specify_unpaired_extensions(grp, i, basename, r_un):
+def specify_unpaired_extensions(grp, i, basename, r_un, r_un_full):
     """
     generates extensions for specification of the number of electrons on a given atom
     """
@@ -856,16 +902,24 @@ def specify_unpaired_extensions(grp, i, basename, r_un):
     label_list = []
 
     Rset = set(r_un)
-    for item in r_un:
-        grp = deepcopy(grp)
+    if isinstance(r_un_full[0],list):
+        r_spc_un_full = [[y for y in x if y in r_un] for x in r_un_full]
+        if len(r_spc_un_full) == 1:
+            r_spc_un_full = [[x] for x in r_spc_un_full[0]]
+        else:
+            r_spc_un_full += [[x] for x in sum(r_spc_un_full,[]) if [x] not in r_spc_un_full]
+    else:
+        r_spc_un_full = [[x] for x in r_un_full if x in r_un]
+    for item in r_spc_un_full:
+        g = deepcopy(grp)
         grpc = deepcopy(grp)
-        grp.atoms[i].radical_electrons = [item]
-        grpc.atoms[i].radical_electrons = list(Rset - {item})
+        g.atoms[i].radical_electrons = item
+        grpc.atoms[i].radical_electrons = list(Rset - set(item))
 
         if len(grpc.atoms[i].radical_electrons) == 0:
             grpc = None
 
-        atom_type = grp.atoms[i].atomtype
+        atom_type = g.atoms[i].atomtype
 
         if len(atom_type) > 1:
             atom_type_str = ""
@@ -879,37 +933,45 @@ def specify_unpaired_extensions(grp, i, basename, r_un):
             atom_type_str = atom_type[0].label
 
         grps.append(
-            (grp, grpc, basename + "_" + str(i + 1) + "-u" + str(item), "elExt", (i,))
+            (g, grpc, basename + "_" + str(i + 1) + "-u" + "".join([str(x) for x in item]), "elExt", (i,))
         )
 
     return grps
 
 
-def specify_site_extensions(grp, i, basename, r_site):
+def specify_site_extensions(grp, i, basename, r_site, r_site_full):
     """
     generates extensions for specification of the number of electrons on a given atom
     """
-    x = ATOMTYPES["X"]
-    if (
-        not any([s.is_specific_case_of(x) for s in grp.atoms[i].atomtype])
-        and grp.atoms[i].atomtype[0] != ATOMTYPES["Rx"]
-    ):
-        return []
+    # x = ATOMTYPES["X"]
+    # if (
+    #     not any([s.is_specific_case_of(x) for s in grp.atoms[i].atomtype])
+    #     and grp.atoms[i].atomtype[0] != ATOMTYPES["Rx"]
+    # ):
+    #     return []
 
     grps = []
     label_list = []
 
     Rset = set(r_site)
-    for item in r_site:
-        grp = deepcopy(grp)
+    if isinstance(r_site_full[0],list):
+        r_spc_site_full = [[y for y in x if y in r_site] for x in r_site_full]
+        if len(r_spc_site_full) == 1:
+            r_spc_site_full = [[x] for x in r_spc_site_full[0]]
+        else:
+            r_spc_site_full += [[x] for x in sum(r_spc_site_full,[]) if [x] not in r_spc_site_full]
+    else:
+        r_spc_site_full = [[x] for x in r_site_full if x in r_site]
+    for item in r_spc_site_full:
+        g = deepcopy(grp)
         grpc = deepcopy(grp)
-        grp.atoms[i].site = [item]
-        grpc.atoms[i].site = list(Rset - {item})
+        g.atoms[i].site = item
+        grpc.atoms[i].site = list(Rset - set(item))
 
         if len(grpc.atoms[i].site) == 0:
             grpc = None
 
-        atom_type = grp.atoms[i].atomtype
+        atom_type = g.atoms[i].atomtype
 
         if len(atom_type) > 1:
             atom_type_str = ""
@@ -923,37 +985,45 @@ def specify_site_extensions(grp, i, basename, r_site):
             atom_type_str = atom_type[0].label
 
         grps.append(
-            (grp, grpc, basename + "_" + str(i + 1) + "-s" + str(item), "siteExt", (i,))
+            (g, grpc, basename + "_" + str(i + 1) + "-s" + "".join([str(x) for x in item]), "siteExt", (i,))
         )
 
     return grps
 
 
-def specify_morphology_extensions(grp, i, basename, r_morph):
+def specify_morphology_extensions(grp, i, basename, r_morph, r_morph_full):
     """
     generates extensions for specification of the number of electrons on a given atom
     """
-    x = ATOMTYPES["X"]
-    if (
-        not any([s.is_specific_case_of(x) for s in grp.atoms[i].atomtype])
-        and grp.atoms[i].atomtype[0] != ATOMTYPES["Rx"]
-    ):
-        return []
+    # x = ATOMTYPES["X"]
+    # if (
+    #     not any([s.is_specific_case_of(x) for s in grp.atoms[i].atomtype])
+    #     and grp.atoms[i].atomtype[0] != ATOMTYPES["Rx"]
+    # ):
+    #     return []
 
     grps = []
     label_list = []
 
     Rset = set(r_morph)
-    for item in r_morph:
-        grp = deepcopy(grp)
+    if isinstance(r_morph_full[0],list):
+        r_spc_morph_full = [[y for y in x if y in r_morph] for x in r_morph_full]
+        if len(r_spc_morph_full) == 1:
+            r_spc_morph_full = [[x] for x in r_spc_morph_full[0]]
+        else:
+            r_spc_morph_full += [[x] for x in sum(r_spc_morph_full,[]) if [x] not in r_spc_morph_full]
+    else:
+        r_spc_morph_full = [[x] for x in r_morph_full if x in r_morph]
+    for item in r_spc_morph_full:
+        g = deepcopy(grp)
         grpc = deepcopy(grp)
-        grp.atoms[i].morphology = [item]
-        grpc.atoms[i].morphology = list(Rset - {item})
+        g.atoms[i].morphology = item
+        grpc.atoms[i].morphology = list(Rset - set(item))
 
         if len(grpc.atoms[i].morphology) == 0:
             grpc = None
 
-        atom_type = grp.atoms[i].atomtype
+        atom_type = g.atoms[i].atomtype
 
         if len(atom_type) > 1:
             atom_type_str = ""
@@ -968,9 +1038,9 @@ def specify_morphology_extensions(grp, i, basename, r_morph):
 
         grps.append(
             (
-                grp,
+                g,
                 grpc,
-                basename + "_" + str(i + 1) + "-m" + str(item),
+                basename + "_" + str(i + 1) + "-m" + "".join([str(x) for x in item]),
                 "morphExt",
                 (i,),
             )
@@ -1074,7 +1144,7 @@ def specify_external_new_bond_extensions(grp, i, basename, r_bonds):
     ]
 
 
-def specify_bond_extensions(grp, i, j, basename, r_bonds):
+def specify_bond_extensions(grp, i, j, basename, r_bonds, r_bonds_full):
     """
     generates extensions for the specification of bond order for a given bond
     """
@@ -1084,19 +1154,27 @@ def specify_bond_extensions(grp, i, j, basename, r_bonds):
     Rbset = set(r_bonds)
     bdict = {1: "-", 2: "=", 3: "#", 1.5: "-=", 4: "$", 0.05: "..", 0: "--"}
     bstrdict = {"S": 1, "D": 2, "T": 3, "B": 1.5, "Q": 4, "R": 0.05, "vdW": 0}
-    for bd in r_bonds:
-        grp = deepcopy(grp)
+    if isinstance(r_bonds_full[0],list):
+        r_spc_bonds_full = [[y for y in x if y in r_bonds] for x in r_bonds_full]
+        if len(r_spc_bonds_full) == 1:
+            r_spc_bonds_full = [[x] for x in r_spc_bonds_full[0]]
+        else:
+            r_spc_bonds_full += [[x] for x in sum(r_spc_bonds_full,[]) if [x] not in r_spc_bonds_full]
+    else:
+        r_spc_bonds_full = [[x] for x in r_bonds_full if x in r_bonds]
+    for bd in r_spc_bonds_full:
+        g = deepcopy(grp)
         grpc = deepcopy(grp)
-        grp.atoms[i].bonds[grp.atoms[j]].order = [bd]
-        grp.atoms[j].bonds[grp.atoms[i]].order = [bd]
-        grpc.atoms[i].bonds[grpc.atoms[j]].order = list(Rbset - {bd})
-        grpc.atoms[j].bonds[grpc.atoms[i]].order = list(Rbset - {bd})
+        g.atoms[i].bonds[g.atoms[j]].order = bd
+        g.atoms[j].bonds[g.atoms[i]].order = bd
+        grpc.atoms[i].bonds[grpc.atoms[j]].order = list(Rbset - set(bd))
+        grpc.atoms[j].bonds[grpc.atoms[i]].order = list(Rbset - set(bd))
 
-        if len(list(Rbset - {bd})) == 0:
+        if len(list(Rbset - set(bd))) == 0:
             grpc = None
 
-        atom_type_i = grp.atoms[i].atomtype
-        atom_type_j = grp.atoms[j].atomtype
+        atom_type_i = g.atoms[i].atomtype
+        atom_type_j = g.atoms[j].atomtype
 
         if len(atom_type_i) > 1:
             atom_type_i_str = ""
@@ -1119,13 +1197,13 @@ def specify_bond_extensions(grp, i, j, basename, r_bonds):
         else:
             atom_type_j_str = atom_type_j[0].label
 
-        b = None
+        b = ""
         for v in bdict.keys():
-            if abs(v - bd) < 1e-4:
-                b = bdict[v]
+            if any(abs(v - x) < 1e-4 for x in bd):
+                b += bdict[v]
         grps.append(
             (
-                grp,
+                g,
                 grpc,
                 basename
                 + "_Sp-"

--- a/pysidt/regularization.py
+++ b/pysidt/regularization.py
@@ -234,7 +234,40 @@ def simple_regularization(tree, node, Rx, Rbonds, Run, Rsite, Rmorph, Rncoord=[]
                         atm1.morphology = vals
                         if not data_matches_node(node, data):
                             atm1.morphology = oldvals
+        
+        if Rncoord and "Ncoord" not in atm1.props.keys():
+            atm1.props["Ncoord"] = Rncoord              
+        if (
+            not skip
+            and Rncoord
+            and atm1.reg_dim_ncoord[1] != []
+            and set(atm1.reg_dim_ncoord[1]) != set(atm1.props["Ncoord"])
+        ):
+            if len(atm1.props["Ncoord"]) == 1:
+                pass
+            else:
+                relist = atm1.props["Ncoord"]
+                if relist == []:
+                    relist = Run
+                vals = list(set(relist) & set(atm1.reg_dim_ncoord[1]))
+                assert vals != [], "cannot regularize to empty"
 
+                if all(
+                    [
+                        set(child_map[q][node.group.atoms[i]].props["Ncoord"]) <= set(vals)
+                        if child_map[q][node.group.atoms[i]].props["Ncoord"] != []
+                        else False
+                        for q,child in enumerate(node.children)
+                    ]
+                ):
+                    if not test:
+                        atm1.props["Ncoord"] = vals
+                    else:
+                        oldvals = atm1.props["Ncoord"]
+                        atm1.props["Ncoord"] = vals
+                        if not data_matches_node(node, data):
+                            atm1.props["Ncoord"] = oldvals
+                            
         if (
             not skip
             and atm1.reg_dim_r[1] != []

--- a/pysidt/regularization.py
+++ b/pysidt/regularization.py
@@ -5,7 +5,7 @@ except:
 from pysidt.utils import data_matches_node
 import itertools
 
-def simple_regularization(node, Rx, Rbonds, Run, Rsite, Rmorph, test=True):
+def simple_regularization(tree, node, Rx, Rbonds, Run, Rsite, Rmorph, Rncoord=[], test=True):
     """
     Simplest regularization algorithm
     All nodes are made as specific as their descendant reactions
@@ -26,7 +26,7 @@ def simple_regularization(node, Rx, Rbonds, Run, Rsite, Rmorph, test=True):
     child_map = []
     for child in node.children:
         #recursively regularize child
-        simple_regularization(child, Rx, Rbonds, Run, Rsite, Rmorph)
+        simple_regularization(tree, child, Rx, Rbonds, Run, Rsite, Rmorph, Rncoord=Rncoord)
         
         #generate atom map to children
         if node.group is not None:
@@ -81,6 +81,9 @@ def simple_regularization(node, Rx, Rbonds, Run, Rsite, Rmorph, test=True):
     
     if grp is None:
         return
+
+    if node.children == []:
+        tree.generate_extensions(node, recursing=False, just_reg_dim=True) #generate regularization dimensions for leaf nodes
 
     R = Rx[:]
     if ATOMTYPES["X"] in R:

--- a/pysidt/regularization.py
+++ b/pysidt/regularization.py
@@ -34,7 +34,7 @@ def simple_regularization(tree, node, Rx, Rbonds, Run, Rsite, Rmorph, Rncoord=[]
             atms = []
             initial_map = dict()
             for atom in child.group.atoms:
-                if atom.label and atom.label != '':
+                if atom.label and atom.label != '' and atom.label != "*S":
                     L = [a for a in node.group.atoms if a.label == atom.label]
                     if L == []:
                         return False

--- a/pysidt/sidt.py
+++ b/pysidt/sidt.py
@@ -118,6 +118,7 @@ class SubgraphIsomorphicDecisionTree:
         r_site=None,
         r_morph=None,
         r_ncoord=None,
+        r_label=None,
         uncertainty_prepruning=False,
         max_nodes=np.inf,
         reverse_extension_generation_allowed=True
@@ -137,6 +138,8 @@ class SubgraphIsomorphicDecisionTree:
             r_morph = []
         if r_ncoord is None:
             r_ncoord = []
+        if r_label is None:
+            r_label = []
         self.nodes = nodes
         self.n_strucs_min = n_strucs_min
         self.iter_max = iter_max
@@ -147,6 +150,7 @@ class SubgraphIsomorphicDecisionTree:
         self.r_site = r_site
         self.r_morph = r_morph
         self.r_ncoord = r_ncoord
+        self.r_label = r_label
         self.skip_nodes = []
         self.uncertainty_prepruning = uncertainty_prepruning
         self.max_nodes = max_nodes
@@ -266,6 +270,7 @@ class SubgraphIsomorphicDecisionTree:
             r_site=self.r_site,
             r_morph=self.r_morph,
             r_ncoord=self.r_ncoord,
+            r_label=self.r_label,
             iter_max=self.iter_max,
             iter_item_cap=self.iter_item_cap,
             just_reg_dim=just_reg_dim

--- a/pysidt/sidt.py
+++ b/pysidt/sidt.py
@@ -542,11 +542,11 @@ class SubgraphIsomorphicDecisionTree:
         simple_regularization(
             self,
             self.nodes["Root"],
-            self.r,
-            self.r_bonds,
-            self.r_un,
-            self.r_site,
-            self.r_morph,
+            self.r if not self.r or not isinstance(self.r[0],list) else sum(self.r,[]),
+            self.r_bonds if not self.r_bonds or not isinstance(self.r_bonds[0],list) else sum(self.r_bonds,[]),
+            self.r_un if not self.r_un or not isinstance(self.r_un[0],list) else sum(self.r_un,[]),
+            self.r_site if not self.r_site or not isinstance(self.r_site[0],list) else sum(self.r_site,[]),
+            self.r_morph if not self.r_morph or not isinstance(self.r_morph[0],list) else sum(self.r_morph,[]),
         )
     
     def scale_uncertainties(self,validation_set=None):

--- a/pysidt/sidt.py
+++ b/pysidt/sidt.py
@@ -121,7 +121,8 @@ class SubgraphIsomorphicDecisionTree:
         r_label=None,
         uncertainty_prepruning=False,
         max_nodes=np.inf,
-        reverse_extension_generation_allowed=True
+        reverse_extension_generation_allowed=True,
+        max_ring_gen_size=None,
     ):
         if nodes is None:
             nodes = {}
@@ -151,6 +152,7 @@ class SubgraphIsomorphicDecisionTree:
         self.r_morph = r_morph
         self.r_ncoord = r_ncoord
         self.r_label = r_label
+        self.max_ring_gen_size = max_ring_gen_size
         self.skip_nodes = []
         self.uncertainty_prepruning = uncertainty_prepruning
         self.max_nodes = max_nodes
@@ -273,7 +275,8 @@ class SubgraphIsomorphicDecisionTree:
             r_label=self.r_label,
             iter_max=self.iter_max,
             iter_item_cap=self.iter_item_cap,
-            just_reg_dim=just_reg_dim
+            just_reg_dim=just_reg_dim,
+            max_ring_gen_size=self.max_ring_gen_size,
         )
 
         if not out and not recursing:
@@ -776,6 +779,7 @@ class MultiEvalSubgraphIsomorphicDecisionTree(SubgraphIsomorphicDecisionTree):
         uncertainty_prepruning=False,
         weigh_node_selection_by_occurrence=True,
         reverse_extension_generation_allowed=True,
+        max_ring_gen_size=None,
     ):
         if nodes is None:
             nodes = dict()
@@ -804,10 +808,9 @@ class MultiEvalSubgraphIsomorphicDecisionTree(SubgraphIsomorphicDecisionTree):
             r_morph=r_morph,
             uncertainty_prepruning=uncertainty_prepruning,
             reverse_extension_generation_allowed=reverse_extension_generation_allowed,
+            max_ring_gen_size=max_ring_gen_size,
         )
 
-        if root_group and (isinstance(decomposition,list) or isinstance(root_group,list)):
-            assert len(decomposition) == len(root_group)
         
         self.fract_nodes_expand_per_iter = fract_nodes_expand_per_iter
         self.weigh_node_selection_by_occurrence = weigh_node_selection_by_occurrence
@@ -1497,6 +1500,7 @@ class MultiEvalSubgraphIsomorphicDecisionTreeBinaryClassifier(MultiEvalSubgraphI
         r_morph=None,
         fract_threshold_to_predict_true=0.5,
         reverse_extension_generation_allowed=True,
+        max_ring_gen_size=None,
     ):
         if nodes is None:
             nodes = dict()
@@ -1526,6 +1530,7 @@ class MultiEvalSubgraphIsomorphicDecisionTreeBinaryClassifier(MultiEvalSubgraphI
             r_site=r_site,
             r_morph=r_morph,
             reverse_extension_generation_allowed=reverse_extension_generation_allowed,
+            max_ring_gen_size=max_ring_gen_size,
             )
 
         self.fract_threshold_to_predict_true = fract_threshold_to_predict_true

--- a/pysidt/sidt.py
+++ b/pysidt/sidt.py
@@ -119,6 +119,7 @@ class SubgraphIsomorphicDecisionTree:
         r_morph=None,
         uncertainty_prepruning=False,
         max_nodes=np.inf,
+        reverse_extension_generation_allowed=True
     ):
         if nodes is None:
             nodes = {}
@@ -150,6 +151,7 @@ class SubgraphIsomorphicDecisionTree:
         self.choose_extension_based_on_subsamples = choose_extension_based_on_subsamples
         self.stuctures_for_extension_generation = None 
         self.node_uncertainties = None
+        self.reverse_extension_generation_allowed = reverse_extension_generation_allowed
         
         if len(nodes) > 0:
             node = nodes[list(nodes.keys())[0]]
@@ -270,7 +272,7 @@ class SubgraphIsomorphicDecisionTree:
             node.group.clear_reg_dims()
             return self.generate_extensions(node, recursing=True)
 
-        if not out:
+        if not out and self.reverse_extension_generation_allowed:
             logging.info("forward extension generation failed, using reverse extension generation")
             grps = generate_extensions_reverse(node.group,structs)
             name = node.name+"_Revgen"
@@ -762,6 +764,7 @@ class MultiEvalSubgraphIsomorphicDecisionTree(SubgraphIsomorphicDecisionTree):
         r_morph=None,
         uncertainty_prepruning=False,
         weigh_node_selection_by_occurrence=True,
+        reverse_extension_generation_allowed=True,
     ):
         if nodes is None:
             nodes = dict()
@@ -789,6 +792,7 @@ class MultiEvalSubgraphIsomorphicDecisionTree(SubgraphIsomorphicDecisionTree):
             r_site=r_site,
             r_morph=r_morph,
             uncertainty_prepruning=uncertainty_prepruning,
+            reverse_extension_generation_allowed=reverse_extension_generation_allowed,
         )
 
         if root_group and (isinstance(decomposition,list) or isinstance(root_group,list)):
@@ -1481,6 +1485,7 @@ class MultiEvalSubgraphIsomorphicDecisionTreeBinaryClassifier(MultiEvalSubgraphI
         r_site=None,
         r_morph=None,
         fract_threshold_to_predict_true=0.5,
+        reverse_extension_generation_allowed=True,
     ):
         if nodes is None:
             nodes = dict()
@@ -1509,6 +1514,7 @@ class MultiEvalSubgraphIsomorphicDecisionTreeBinaryClassifier(MultiEvalSubgraphI
             r_un=r_un,
             r_site=r_site,
             r_morph=r_morph,
+            reverse_extension_generation_allowed=reverse_extension_generation_allowed,
             )
 
         self.fract_threshold_to_predict_true = fract_threshold_to_predict_true

--- a/pysidt/sidt.py
+++ b/pysidt/sidt.py
@@ -235,7 +235,7 @@ class SubgraphIsomorphicDecisionTree:
         else:
             return None
 
-    def generate_extensions(self, node, recursing=False):
+    def generate_extensions(self, node, recursing=False, just_reg_dim=False):
         """
         Generates set of extension groups to a node
         returns list of Groups
@@ -264,6 +264,7 @@ class SubgraphIsomorphicDecisionTree:
             r_morph=self.r_morph,
             iter_max=self.iter_max,
             iter_item_cap=self.iter_item_cap,
+            just_reg_dim=just_reg_dim
         )
 
         if not out and not recursing:
@@ -539,6 +540,7 @@ class SubgraphIsomorphicDecisionTree:
             self.descend_training_from_top(only_specific_match=False)
 
         simple_regularization(
+            self,
             self.nodes["Root"],
             self.r,
             self.r_bonds,

--- a/pysidt/sidt.py
+++ b/pysidt/sidt.py
@@ -117,6 +117,7 @@ class SubgraphIsomorphicDecisionTree:
         r_un=None,
         r_site=None,
         r_morph=None,
+        r_ncoord=None,
         uncertainty_prepruning=False,
         max_nodes=np.inf,
         reverse_extension_generation_allowed=True
@@ -134,7 +135,8 @@ class SubgraphIsomorphicDecisionTree:
             r_site = []
         if r_morph is None:
             r_morph = []
-
+        if r_ncoord is None:
+            r_ncoord = []
         self.nodes = nodes
         self.n_strucs_min = n_strucs_min
         self.iter_max = iter_max
@@ -144,6 +146,7 @@ class SubgraphIsomorphicDecisionTree:
         self.r_un = r_un
         self.r_site = r_site
         self.r_morph = r_morph
+        self.r_ncoord = r_ncoord
         self.skip_nodes = []
         self.uncertainty_prepruning = uncertainty_prepruning
         self.max_nodes = max_nodes
@@ -262,6 +265,7 @@ class SubgraphIsomorphicDecisionTree:
             r_un=self.r_un,
             r_site=self.r_site,
             r_morph=self.r_morph,
+            r_ncoord=self.r_ncoord,
             iter_max=self.iter_max,
             iter_item_cap=self.iter_item_cap,
             just_reg_dim=just_reg_dim

--- a/pysidt/utils.py
+++ b/pysidt/utils.py
@@ -16,3 +16,23 @@ def data_matches_node(node, data):
             return False
     else:
         return True
+
+def find_shortest_paths(start, end, path=None):
+    paths = [[start]]
+    outpaths = []
+    while paths != []:
+        newpaths = []
+        for path in paths:
+            for node in path[-1].edges.keys():
+                if node in path:
+                    continue
+                elif node is end:
+                    outpaths.append(path[:]+[node])
+                elif outpaths == []:
+                    newpaths.append(path[:]+[node])
+        if outpaths:
+            return outpaths
+        else:
+            paths = newpaths
+    
+    return None


### PR DESCRIPTION
This adds new extensions for forming rings, coordination number of atoms, and allows specification attributes to be expressed as sublists that can individually be split on (ex: [[F,Cl,Br],[O][C]]=> [F,Cl,Br]). 

Additionally, allows reverse extension generation to be turned off and ensures regularization dimensions are computed for leaf nodes as needed during regularization. 